### PR TITLE
Feat/32 InputFile 컴포넌트 구현

### DIFF
--- a/src/app/design-system/ui-inputfile/page.tsx
+++ b/src/app/design-system/ui-inputfile/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+
+import InputFile from '@/components/Inputs/InputFile';
+import ProfileImg from '@/components/ProfileImg';
+
+export default function UiInputFile() {
+  const [previewSrc, setPreviewSrc] = useState('');
+
+  return (
+    <div className='p-8'>
+      <h1 className='mb-3 text-3xl font-bold text-gray-900'>
+        InputFile Component
+      </h1>
+
+      <div className='content-text w-full bg-gray-50 p-3 leading-8 text-gray-600'>
+        <p>
+          <strong>- label:</strong> input 요소의 label로 사용되며, id 및
+          name에도 동일하게 적용됩니다.
+        </p>
+        <p>
+          <strong>- children:</strong> 클릭 시 파일 선택을 유도하는 커스텀
+          트리거 요소입니다. (예: 이미지, 버튼 등)
+        </p>
+        <p>
+          <strong>- accept:</strong> 허용할 파일의 MIME 타입 지정. (예:
+          "image/*", ".pdf")
+        </p>
+        <p className='pb-4'>
+          <strong>- onChange:</strong> 파일이 선택되면 해당 파일의 Blob URL을
+          콜백으로 전달합니다.
+        </p>
+
+        <h3>Example Code</h3>
+        <div className='mt-4 rounded bg-white p-3 text-sm text-gray-700'>
+          <pre>
+            <code>
+              {`<InputFile onChange={setPreviewSrc}>
+  <ProfileImg size="lg" src={previewSrc || undefined} isSelectable />
+</InputFile>`}
+            </code>
+          </pre>
+        </div>
+      </div>
+
+      <h2 className='mt-10 mb-3 text-xl font-bold text-gray-700'>Example</h2>
+      <div className='flex flex-col items-start gap-5'>
+        <InputFile onChange={setPreviewSrc}>
+          <ProfileImg isSelectable size='lg' src={previewSrc || undefined} />
+        </InputFile>
+
+        <p className='text-sm text-gray-500'>
+          위의 이미지를 클릭하면 이미지 파일 선택창이 열립니다. <br />
+          선택된 이미지는 미리보기로 표시됩니다.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Inputs/InputFile.tsx
+++ b/src/components/Inputs/InputFile.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useRef } from 'react';
+
+import Input from './Input';
+
+type NativeInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'onChange'
+>;
+
+interface InputFileProps extends NativeInputProps {
+  label?: string;
+  children: React.ReactNode;
+  onChange?: React.Dispatch<React.SetStateAction<string>>;
+  accept?: string;
+}
+
+/**
+ * InputFile 컴포넌트
+ *
+ * 커스텀 트리거 요소를 클릭하여 파일을 선택하고,
+ * 선택된 파일의 URL을 상위 컴포넌트로 전달합니다.
+ *
+ *  @param {string} [label] - input의 라벨 텍스트. `id`, `name`에도 함께 사용됨
+ * @param {React.ReactNode} children - 클릭 가능한 커스텀 트리거 요소
+ * @param {(fileUrl: string | null) => void} [onChange] - 파일 선택 시 호출되는 함수 URL 또는 null 반환
+ * @param {string} [accept] - 업로드 가능한 파일의 MIME 타입 (기본값: "image/*")
+ * @param {...NativeInputProps} props - 기타 기본 input 속성
+ *
+ * @example
+ * ```tsx
+ * <InputFile onChange={(url) => setImage(url)}>
+ *   <ProfileImg />
+ * </InputFile>
+ * ```
+ */
+export default function InputFile({
+  label,
+  children,
+  onChange,
+  accept,
+  ...inputProps
+}: InputFileProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleClick = () => {
+    inputRef.current?.click();
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    const url = file ? URL.createObjectURL(file) : '';
+    onChange?.(url);
+  };
+
+  return (
+    <div className='inline-block'>
+      {label && (
+        <label
+          className='mb-1 block text-sm font-medium text-gray-700'
+          htmlFor={label}
+        >
+          {label}
+        </label>
+      )}
+      <div className='inline-block cursor-pointer' onClick={handleClick}>
+        {children}
+      </div>
+      <Input
+        ref={inputRef}
+        accept={accept ?? 'image/*'}
+        className='hidden'
+        id={label}
+        name={label}
+        type='file'
+        onChange={handleChange}
+        {...inputProps}
+      />
+    </div>
+  );
+}

--- a/src/components/ProfileImg.tsx
+++ b/src/components/ProfileImg.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image, { StaticImageData } from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import defaultImg from '@/app/assets/svgs/profile-default.svg';
 import selectedOverlayImg from '@/app/assets/svgs/profile-select-overlay.svg';
@@ -55,6 +55,10 @@ export default function ProfileImg({
   );
   const [isError, setIsError] = useState(false);
 
+  useEffect(() => {
+    if (src) setImgSrc(src);
+  }, [src]);
+
   const handleError = () => {
     if (!isError) {
       setIsError(true);
@@ -76,7 +80,7 @@ export default function ProfileImg({
           alt='프로필 이미지'
           className='pointer-events-none object-cover object-center select-none'
           src={imgSrc}
-          onError={() => handleError}
+          onError={handleError}
         />
         {isSelectable && (
           <div


### PR DESCRIPTION
### 📌 관련 이슈

- #32 

### 📋 작업 내용

-  **추갸된 파일**
- `components/Inputs/InputFile.tsx`
- `design-system/ui-inputfile`

- **변경된 파일**
  - `components/ProfileImg.tsx`
    → src` 이미지 경로가 변경됨에 따라 `useEffect`를 활용해 이미지 변경이 반영되도록 했습니다.

- **InputFile 공통 컴포넌트 구현**
  - 커스텀 트리거 요소(children)를 클릭하여 파일 선택 가능
  
  - 선택된 파일은 URL.createObjectURL()로 변환 후 onChange 콜백으로 전달
  
  - label prop을 통해 <label> 렌더링 및 id, name에 자동 적용
  
  - 기본 accept는 "image/*"이며, 필요시 커스터마이징 가능
  
  - 내부적으로 기본 input[type="file"] 요소는 hidden 처리
  
  - 기타 input 속성은 ...inputProps로 확장 가능

### 📷 결과 및 스크린샷

<img src="https://github.com/user-attachments/assets/676ee084-7b35-47f5-8d35-d8b3d708c0b5" width="400" alt="inputfile" />

### 🔎 참고 (선택)
