### PR TITLE
배포 환경에서 Button의 아이콘이 보이지 않는 오류 해결

### DIFF
--- a/src/app/assets/icons/arrow.tsx
+++ b/src/app/assets/icons/arrow.tsx
@@ -43,3 +43,5 @@ export default function ArrowIcon({
     </svg>
   );
 }
+
+ArrowIcon.displayName = 'ArrowIcon';

--- a/src/app/assets/icons/camera.tsx
+++ b/src/app/assets/icons/camera.tsx
@@ -33,3 +33,5 @@ export default function CameraIcon({
     </svg>
   );
 }
+
+CameraIcon.displayName = 'CameraIcon';

--- a/src/app/assets/icons/chevron-arrow.tsx
+++ b/src/app/assets/icons/chevron-arrow.tsx
@@ -43,3 +43,5 @@ export default function ChevronArrowIcon({
     </svg>
   );
 }
+
+ChevronArrowIcon.displayName = 'ChevronArrowIcon';

--- a/src/app/assets/icons/close.tsx
+++ b/src/app/assets/icons/close.tsx
@@ -33,3 +33,5 @@ export default function CloseIcon({
     </svg>
   );
 }
+
+CloseIcon.displayName = 'CloseIcon';

--- a/src/app/assets/icons/filter.tsx
+++ b/src/app/assets/icons/filter.tsx
@@ -33,3 +33,5 @@ export default function FilterIcon({
     </svg>
   );
 }
+
+FilterIcon.displayName = 'FilterIcon';

--- a/src/app/assets/icons/github-logo.tsx
+++ b/src/app/assets/icons/github-logo.tsx
@@ -15,3 +15,5 @@ export default function GitHubLogo() {
     </svg>
   );
 }
+
+GitHubLogo.displayName = 'GitHubLogo';

--- a/src/app/assets/icons/google-login.tsx
+++ b/src/app/assets/icons/google-login.tsx
@@ -28,3 +28,5 @@ export default function GoogleLoginIcon({ size = 24 }: BaseIconProps) {
     </svg>
   );
 }
+
+GoogleLoginIcon.displayName = 'GoogleLoginIcon';

--- a/src/app/assets/icons/heart.tsx
+++ b/src/app/assets/icons/heart.tsx
@@ -37,3 +37,5 @@ export default function HeartIcon({
     </svg>
   );
 }
+
+HeartIcon.displayName = 'HeartIcon';

--- a/src/app/assets/icons/kakao-login.tsx
+++ b/src/app/assets/icons/kakao-login.tsx
@@ -16,3 +16,5 @@ export default function KakaoLoginIcon({ size = 24 }: BaseIconProps) {
     </svg>
   );
 }
+
+KakaoLoginIcon.displayName = 'KakaoLoginIcon';

--- a/src/app/assets/icons/loader-circle.tsx
+++ b/src/app/assets/icons/loader-circle.tsx
@@ -21,3 +21,5 @@ export default function LoaderCircleIcon({
     </svg>
   );
 }
+
+LoaderCircleIcon.displayName = 'LoaderCircleIcon';

--- a/src/app/assets/icons/search.tsx
+++ b/src/app/assets/icons/search.tsx
@@ -21,3 +21,5 @@ export default function SearchIcon({
     </svg>
   );
 }
+
+SearchIcon.displayName = 'SearchIcon';

--- a/src/app/assets/icons/star.tsx
+++ b/src/app/assets/icons/star.tsx
@@ -37,3 +37,5 @@ export default function StarIcon({
     </svg>
   );
 }
+
+StarIcon.displayName = 'StarIcon';

--- a/src/app/assets/icons/triangle-arrow.tsx
+++ b/src/app/assets/icons/triangle-arrow.tsx
@@ -43,3 +43,5 @@ export default function TriangleArrowIcon({
     </svg>
   );
 }
+
+TriangleArrowIcon.displayName = 'TriangleArrowIcon';

--- a/src/app/assets/icons/vertical-more.tsx
+++ b/src/app/assets/icons/vertical-more.tsx
@@ -43,3 +43,5 @@ export default function VerticalMoreIcon({
     </svg>
   );
 }
+
+VerticalMoreIcon.displayName = 'VerticalMoreIcon';

--- a/src/app/assets/icons/wine-logo.tsx
+++ b/src/app/assets/icons/wine-logo.tsx
@@ -28,3 +28,5 @@ export default function WineLogoIcon({
     </svg>
   );
 }
+
+WineLogoIcon.displayName = 'WineLogoIcon';

--- a/src/app/assets/icons/wine.tsx
+++ b/src/app/assets/icons/wine.tsx
@@ -47,3 +47,5 @@ export default function WineIcon({ size = 24 }: BaseIconProps) {
     </svg>
   );
 }
+
+WineIcon.displayName = 'WineIcon';

--- a/src/app/assets/tastes/apple.tsx
+++ b/src/app/assets/tastes/apple.tsx
@@ -57,3 +57,5 @@ export default function AppleIcon({
     </svg>
   );
 }
+
+AppleIcon.displayName = 'AppleIcon';

--- a/src/app/assets/tastes/berry.tsx
+++ b/src/app/assets/tastes/berry.tsx
@@ -58,3 +58,5 @@ export default function BerryIcon({
     </svg>
   );
 }
+
+BerryIcon.displayName = 'BerryIcon';

--- a/src/app/assets/tastes/cherry.tsx
+++ b/src/app/assets/tastes/cherry.tsx
@@ -85,3 +85,5 @@ export default function CherryIcon({
     </svg>
   );
 }
+
+CherryIcon.displayName = 'CherryIcon';

--- a/src/app/assets/tastes/chocolate.tsx
+++ b/src/app/assets/tastes/chocolate.tsx
@@ -65,3 +65,5 @@ export default function ChocolateIcon({
     </svg>
   );
 }
+
+ChocolateIcon.displayName = 'ChocolateIcon';

--- a/src/app/assets/tastes/citrus.tsx
+++ b/src/app/assets/tastes/citrus.tsx
@@ -73,3 +73,5 @@ export default function CitrusIcon({
     </svg>
   );
 }
+
+CitrusIcon.displayName = 'CitrusIcon';

--- a/src/app/assets/tastes/coconut.tsx
+++ b/src/app/assets/tastes/coconut.tsx
@@ -41,3 +41,5 @@ export default function CoconutIcon({
     </svg>
   );
 }
+
+CoconutIcon.displayName = 'CoconutIcon';

--- a/src/app/assets/tastes/earthy.tsx
+++ b/src/app/assets/tastes/earthy.tsx
@@ -71,3 +71,5 @@ export default function EarthyIcon({
     </svg>
   );
 }
+
+EarthyIcon.displayName = 'EarthyIcon';

--- a/src/app/assets/tastes/floral.tsx
+++ b/src/app/assets/tastes/floral.tsx
@@ -49,3 +49,5 @@ export default function FloralIcon({
     </svg>
   );
 }
+
+FloralIcon.displayName = 'FloralIcon';

--- a/src/app/assets/tastes/herbal.tsx
+++ b/src/app/assets/tastes/herbal.tsx
@@ -34,3 +34,5 @@ export default function HerbalIcon({
     </svg>
   );
 }
+
+HerbalIcon.displayName = 'HerbalIcon';

--- a/src/app/assets/tastes/honey.tsx
+++ b/src/app/assets/tastes/honey.tsx
@@ -49,3 +49,5 @@ export default function HoneyIcon({
     </svg>
   );
 }
+
+HoneyIcon.displayName = 'HoneyIcon';

--- a/src/app/assets/tastes/leather.tsx
+++ b/src/app/assets/tastes/leather.tsx
@@ -34,3 +34,5 @@ export default function LeatherIcon({
     </svg>
   );
 }
+
+LeatherIcon.displayName = 'LeatherIcon';

--- a/src/app/assets/tastes/mineral.tsx
+++ b/src/app/assets/tastes/mineral.tsx
@@ -54,3 +54,5 @@ export default function MineralIcon({
     </svg>
   );
 }
+
+MineralIcon.displayName = 'MineralIcon';

--- a/src/app/assets/tastes/mint.tsx
+++ b/src/app/assets/tastes/mint.tsx
@@ -45,3 +45,5 @@ export default function MintIcon({
     </svg>
   );
 }
+
+MintIcon.displayName = 'MintIcon';

--- a/src/app/assets/tastes/oak.tsx
+++ b/src/app/assets/tastes/oak.tsx
@@ -74,3 +74,5 @@ export default function OakIcon({
     </svg>
   );
 }
+
+OakIcon.displayName = 'OakIcon';

--- a/src/app/assets/tastes/peach.tsx
+++ b/src/app/assets/tastes/peach.tsx
@@ -49,3 +49,5 @@ export default function PeachIcon({
     </svg>
   );
 }
+
+PeachIcon.displayName = 'PeachIcon';

--- a/src/app/assets/tastes/pepper.tsx
+++ b/src/app/assets/tastes/pepper.tsx
@@ -65,3 +65,5 @@ export default function PepperIcon({
     </svg>
   );
 }
+
+PepperIcon.displayName = 'PepperIcon';

--- a/src/app/assets/tastes/spicy.tsx
+++ b/src/app/assets/tastes/spicy.tsx
@@ -46,3 +46,5 @@ export default function SpicyIcon({
     </svg>
   );
 }
+
+SpicyIcon.displayName = 'SpicyIcon';

--- a/src/app/assets/tastes/toasty.tsx
+++ b/src/app/assets/tastes/toasty.tsx
@@ -45,3 +45,5 @@ export default function ToastyIcon({
     </svg>
   );
 }
+
+ToastyIcon.displayName = 'ToastyIcon';

--- a/src/app/assets/tastes/tropical.tsx
+++ b/src/app/assets/tastes/tropical.tsx
@@ -95,3 +95,5 @@ export default function TropicalIcon({
     </svg>
   );
 }
+
+TropicalIcon.displayName = 'TropicalIcon';

--- a/src/app/assets/tastes/vanilla.tsx
+++ b/src/app/assets/tastes/vanilla.tsx
@@ -54,3 +54,5 @@ export default function VanillaIcon({
     </svg>
   );
 }
+
+VanillaIcon.displayName = 'VanillaIcon';

--- a/src/app/assets/tastes/wild-flower.tsx
+++ b/src/app/assets/tastes/wild-flower.tsx
@@ -89,3 +89,5 @@ export default function WildFlowerIcon({
     </svg>
   );
 }
+
+WildFlowerIcon.displayName = 'WildFlowerIcon';

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { Children, isValidElement } from 'react';
+import { Children, isValidElement } from 'react';
 
 import LoaderCircleIcon from '@/app/assets/icons/loader-circle';
 import {
@@ -10,6 +10,10 @@ import {
   LOADER_VARIANTS,
 } from '@/constants/button';
 import { cn } from '@/libs/cn';
+
+type DisplayNameType = {
+  displayName?: string;
+};
 
 interface ButtonProps
   extends Omit<
@@ -103,8 +107,8 @@ export default function Button({
       typeof child === 'string' ||
       (isValidElement(child) &&
         typeof child.type === 'function' &&
-        (child.type.name?.includes('Icon') ||
-          child.type.name?.includes('Image'))),
+        ((child.type as DisplayNameType).displayName?.includes('Icon') ||
+          (child.type as DisplayNameType).displayName?.includes('Image'))),
   );
 
   return (


### PR DESCRIPTION
### 📌 관련 이슈

- #51

### 📋 작업 내용

### 오류 발생 상황
`Button` 공통 컴포넌트는 `children`으로 버튼에 보여질 내용을 전달 받고 있습니다.
```tsx
        <Button round='rounded' size='lg' variant='outline' onClick={click}>
          <GoogleLoginIcon size={20} />
          Google로 시작하기
        </Button>
```
기존에는 `input`과 같이 버튼의 내용으로 사용할 수 없는 요소를 걸러내기 위해 `child.type.name` 속성에 `Icon` 혹은 `Image` 문자열이 포함되어 있나 확인하고 있었습니다.
이 부분이 로컬의 개발 서버에서는 문제 없이 작동했지만, 빌드 이후 배포 환경에서는 아이콘이 보이지 않는 오류가 있었습니다.

### 원인

`children`에는 기본적으로 `name` 속성이 포함되어 있습니다.
하지만 빌드시 minify(난독화) 되기 때문에 사라지면서 빌드 이후에는 사용할 수 없습니다.
따라서 난독화가 되지 않는 `displayName`을 사용해야 합니다.

### 해결

1. 모든 아이콘에 `displayName` 속성을 추가했습니다.
2. `displayName` 속성을 사용하여 `Button` 컴포넌트에서 유효한 요소를 필터링했습니다.
```tsx
  const validChildren = childrenArray.filter(
    (child) =>
      typeof child === 'string' ||
      (isValidElement(child) &&
        typeof child.type === 'function' &&
        ((child.type as DisplayNameType).displayName?.includes('Icon') ||
          (child.type as DisplayNameType).displayName?.includes('Image'))),
  );
```

### 📷 결과 및 스크린샷

빌드 후 로컬 서버에서 확인했을 때, 정상적으로 아이콘이 출력되는 것을 확인했습니다.
![image](https://github.com/user-attachments/assets/45cea58b-df40-4e21-8aba-3ab8558526bd)


### 🔎 참고 (선택)
https://emewjin.github.io/react-child/