### PR TITLE
양방향 range input 컴포넌트 & 가격 범위 조정 컴포넌트 개발

### DIFF
--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -50,6 +50,12 @@ export default function DesignSystem() {
           slug='ui-recommend-wine-item'
           title='Recommend Wine Item Components'
         />
+
+        <LinkButton
+          description='View all Dual Range Slider examples'
+          slug='ui-dual-range-slider'
+          title='Dual Range Slider Components'
+        />
       </div>
     </div>
   );

--- a/src/app/design-system/ui-dual-range-slider/page.tsx
+++ b/src/app/design-system/ui-dual-range-slider/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+
+import DualRangeSlider from '@/app/wines/components/DualRangeSlider';
+import PriceRangeSlider from '@/app/wines/components/PriceRangeSlider';
+
+export default function UiDualRangeSlider() {
+  const max = 10000;
+  const [minPrice, setMinPrice] = useState(0);
+  const [maxPrice, setMaxPrice] = useState(max);
+
+  return (
+    <div className='p-8'>
+      <h1 className='mb-3 text-3xl font-bold text-gray-900'>
+        Dual Range Slider
+      </h1>
+
+      <h2 className='mt-10 mb-3 text-xl font-bold text-gray-700'>Example</h2>
+
+      <div className='mt-10'>
+        <DualRangeSlider
+          endValue={max}
+          gap={100}
+          startValue={0}
+          onMaxValueChange={(value) => setMaxPrice(value)}
+          onMinValueChange={(value) => setMinPrice(value)}
+        />
+      </div>
+
+      <p className='content-text mt-10'>
+        {minPrice.toLocaleString()}원 ~ {maxPrice.toLocaleString()}원
+      </p>
+
+      <div className='mt-48'>
+        <PriceRangeSlider />
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,3 +103,17 @@
     @apply text-[1.2rem] font-normal; /* 12px */
   }
 }
+
+@layer utilities {
+  .range-slider {
+    @apply absolute -top-[0.6rem] h-2 w-full appearance-none bg-transparent md:-top-[0.7rem];
+    pointer-events: none;
+  }
+
+  .range-slider::-webkit-slider-thumb {
+    @apply size-6 rounded-full border-1 border-gray-300 bg-white md:size-8;
+    -webkit-appearance: none;
+    pointer-events: auto;
+    cursor: pointer;
+  }
+}

--- a/src/app/wines/components/DualRangeSlider.tsx
+++ b/src/app/wines/components/DualRangeSlider.tsx
@@ -46,15 +46,16 @@ export default function DualRangeSlider({
   const [rangeMaxValue, setRangeMaxValue] = useState(endValue);
   const [rangeMinPercent, setRangeMinPercent] = useState(0);
   const [rangeMaxPercent, setRangeMaxPercent] = useState(0);
+  const disabledGap = gap * 5;
 
   /** 최소값 슬라이더 변경 핸들러 */
   const rangeMinValueHandler = (e: ChangeEvent<HTMLInputElement>) => {
     const newMinValue = parseInt(e.target.value);
 
-    if (newMinValue >= rangeMaxValue - gap) {
+    if (newMinValue >= rangeMaxValue - disabledGap) {
       // min이 max보다 커지면 max도 같이 함께 커진다.
-      const newMaxValue = Math.min(newMinValue + gap, endValue);
-      const adjustedMinValue = newMaxValue - gap;
+      const newMaxValue = Math.min(newMinValue + disabledGap, endValue);
+      const adjustedMinValue = newMaxValue - disabledGap;
 
       setRangeMinValue(adjustedMinValue);
       setRangeMaxValue(newMaxValue);
@@ -70,10 +71,10 @@ export default function DualRangeSlider({
   const rangeMaxValueHandler = (e: ChangeEvent<HTMLInputElement>) => {
     const newMaxValue = parseInt(e.target.value);
 
-    if (newMaxValue <= rangeMinValue + gap) {
+    if (newMaxValue <= rangeMinValue + disabledGap) {
       // max가 min보다 작아지면 min도 같이 함께 작아진다.
-      const newMinValue = Math.max(newMaxValue - gap, startValue);
-      const adjustedMaxValue = newMinValue + gap;
+      const newMinValue = Math.max(newMaxValue - disabledGap, startValue);
+      const adjustedMaxValue = newMinValue + disabledGap;
 
       setRangeMinValue(newMinValue);
       setRangeMaxValue(adjustedMaxValue);

--- a/src/app/wines/components/DualRangeSlider.tsx
+++ b/src/app/wines/components/DualRangeSlider.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { ChangeEvent, useState } from 'react';
+
+interface DualRangeSliderProps {
+  startValue?: number;
+  endValue?: number;
+  gap?: number;
+  onMinValueChange: (value: number) => void;
+  onMaxValueChange: (value: number) => void;
+}
+
+/**
+ * Dual Range Slider
+ *
+ * @description 최소값과 최대값을 동시에 조정하는 range input입니다.
+ *
+ * @param startValue - 슬라이더의 시작값 (기본값: 0)
+ * @param endValue - 슬라이더의 끝값 (기본값: 100)
+ * @param gap - 최소값과 최대값 사이의 최소 간격 (기본값: 1)
+ * @param onMinValueChange - 최소값이 변경될 때 호출되는 콜백 함수
+ * @param onMaxValueChange - 최대값이 변경될 때 호출되는 콜백 함수
+ *
+ * @example
+ * ```
+ * const [minPrice, setMinPrice] = useState(0);
+ * const [maxPrice, setMaxPrice] = useState(100);
+ *
+ * <DualRangeSlider
+ *   startValue={0}
+ *   endValue={1000}
+ *   gap={10}
+ *   onMinValueChange={setMinPrice}
+ *   onMaxValueChange={setMaxPrice}
+ * />
+ * ```
+ */
+export default function DualRangeSlider({
+  startValue = 0,
+  endValue = 100,
+  gap = 1,
+  onMinValueChange,
+  onMaxValueChange,
+}: DualRangeSliderProps) {
+  const [rangeMinValue, setRangeMinValue] = useState(startValue);
+  const [rangeMaxValue, setRangeMaxValue] = useState(endValue);
+  const [rangeMinPercent, setRangeMinPercent] = useState(0);
+  const [rangeMaxPercent, setRangeMaxPercent] = useState(0);
+
+  /** 최소값 슬라이더 변경 핸들러 */
+  const rangeMinValueHandler = (e: ChangeEvent<HTMLInputElement>) => {
+    const newMinValue = parseInt(e.target.value);
+
+    if (newMinValue >= rangeMaxValue - gap) {
+      // min이 max보다 커지면 max도 같이 함께 커진다.
+      const newMaxValue = Math.min(newMinValue + gap, endValue);
+      const adjustedMinValue = newMaxValue - gap;
+
+      setRangeMinValue(adjustedMinValue);
+      setRangeMaxValue(newMaxValue);
+      onMinValueChange?.(adjustedMinValue);
+      onMaxValueChange?.(newMaxValue);
+    } else {
+      setRangeMinValue(newMinValue);
+      onMinValueChange?.(newMinValue);
+    }
+  };
+
+  /** 최대값 슬라이더 변경 핸들러 */
+  const rangeMaxValueHandler = (e: ChangeEvent<HTMLInputElement>) => {
+    const newMaxValue = parseInt(e.target.value);
+
+    if (newMaxValue <= rangeMinValue + gap) {
+      // max가 min보다 작아지면 min도 같이 함께 작아진다.
+      const newMinValue = Math.max(newMaxValue - gap, startValue);
+      const adjustedMaxValue = newMinValue + gap;
+
+      setRangeMinValue(newMinValue);
+      setRangeMaxValue(adjustedMaxValue);
+      onMinValueChange?.(newMinValue);
+      onMaxValueChange?.(adjustedMaxValue);
+    } else {
+      setRangeMaxValue(newMaxValue);
+      onMaxValueChange?.(newMaxValue);
+    }
+  };
+
+  /** 슬라이더 UI 업데이트 핸들러 */
+  const dualRangeUiHandler = () => {
+    setRangeMinPercent((rangeMinValue / endValue) * 100);
+    setRangeMaxPercent(100 - (rangeMaxValue / endValue) * 100);
+  };
+
+  return (
+    <>
+      <div className='relative h-[0.7rem] w-full rounded-2xl bg-gray-100 md:h-[1rem]'>
+        <div
+          className='bg-primary-100 absolute right-[30%] left-[30%] h-[0.7rem] rounded-2xl md:h-[1rem]'
+          style={{
+            left: `${rangeMinPercent}%`,
+            right: `${rangeMaxPercent}%`,
+          }}
+        />
+      </div>
+
+      <div className='relative'>
+        <input
+          className='range-slider'
+          max={endValue - gap}
+          min={startValue}
+          step={gap}
+          type='range'
+          value={rangeMinValue}
+          onChange={(e) => {
+            rangeMinValueHandler(e);
+            dualRangeUiHandler();
+          }}
+        />
+        <input
+          className='range-slider'
+          max={endValue}
+          min={startValue + gap}
+          step={gap}
+          type='range'
+          value={rangeMaxValue}
+          onChange={(e) => {
+            rangeMaxValueHandler(e);
+            dualRangeUiHandler();
+          }}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/app/wines/components/PriceRangeSlider.tsx
+++ b/src/app/wines/components/PriceRangeSlider.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+
+import DualRangeSlider from './DualRangeSlider';
+
+export default function PriceRangeSlider() {
+  const max = 10000; // dummy => 와인 데이터에서 최대 값으로 변경 예정
+  const [minPrice, setMinPrice] = useState(0);
+  const [maxPrice, setMaxPrice] = useState(max);
+
+  return (
+    <div className='w-1/2'>
+      <h1 className='sub-title-text text-gray-800'>PRICE</h1>
+      <p className='content-text text-primary-100 mt-3 mb-8'>
+        <span className='sub-content-text mr-1 text-gray-400'>₩</span>
+        {minPrice.toLocaleString('ko-KR')}
+        <span className='mx-2 text-gray-400'>~</span>
+        <span className='sub-content-text mr-1 text-gray-400'>₩</span>
+        {maxPrice.toLocaleString('ko-KR')}
+      </p>
+      <DualRangeSlider
+        endValue={max}
+        gap={100}
+        startValue={0}
+        onMaxValueChange={(value) => setMaxPrice(value)}
+        onMinValueChange={(value) => setMinPrice(value)}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
### 📌 관련 이슈

- #64

### 📋 작업 내용

**DualRangeSlider 컴포넌트**
- 범위 시작과 끝 값, 간격 등을 props으로 받는 양방향 range input입니다.
- 🚨 range가 수정될 때 `min`과 `max`가 너무 가까워지면 두 포인터가 붙어 정상적으로 작동하지 않는 오류가 발생했습니다. 따라서 min과 max의 최소 간격을 설정해두었습니다. (props로 받는 간격의 5배)

**PriceRangeSlider 컴포넌트**
- 와인 목록 페이지에서 가격을 필터링할 때 사용됩니다.
- 페이지를 어떤 방식으로 구현하냐에 따라 props 부분은 변경 될 수 있습니다.

### 📷 결과 및 스크린샷

최소 간격 설정 X
![dualRangeSlider](https://github.com/user-attachments/assets/ed43a8f2-24f6-4de9-bf7a-ff6ca5d506cb)

최소 간격 설정 후
![dualRangeSlide-gap](https://github.com/user-attachments/assets/080f5cb8-b653-4257-966c-cf965839b4fb)



### 🔎 참고 (선택)

피그마에서는 range 포인트 위에 가격이 적혀있습니다. 이렇게 구현되면 사용자가 범위를 좁혔을 때 두 가격이 겹치는 문제가 발생할 수 있어서, 부득이하게 range input과 분리하였습니다.
이 부분에 대해 이전 디자인이 더 낫다고 생각하시거나 더 좋은 디자인이 생각나시면 말씀해주세요! 피드백 주신 내용으로 수정해보겠습니다 🙏🏻

> 기존 피그마 디자인
![image](https://github.com/user-attachments/assets/a4977338-1dc4-434e-8fd2-18f54d790887)
