### PR TITLE
wineInfo에서 PriceBadge의 import 경로 수정

### DIFF
--- a/src/components/WineInfo.tsx
+++ b/src/components/WineInfo.tsx
@@ -1,8 +1,7 @@
 import Image, { StaticImageData } from 'next/image';
 
+import PriceBadge from '@/components/Badge/PriceBadge';
 import { cn } from '@/libs/cn';
-
-import PriceBadge from './PriceBadge';
 
 interface WineInfoProps {
   /**


### PR DESCRIPTION
### 📌 관련 이슈

- #69

### 📋 작업 내용

- `wineInfo` 컴포넌트에서 `PriceBadge`컴포넌트의 import 경로를 올바르게 수정했습니다.
  → 로컬에서 빌드 성공한 것까지 확인했습니다~

### 📷 결과 및 스크린샷

-

### 🔎 참고 (선택)
