### PR TITLE
와인 목록 페이지의 Wine List Card 컴포넌트 개발

### DIFF
--- a/src/app/design-system/page.tsx
+++ b/src/app/design-system/page.tsx
@@ -56,6 +56,12 @@ export default function DesignSystem() {
           slug='ui-multi-select'
           title='Multi Select Components'
         />
+
+        <LinkButton
+          description='View wine list card component examples'
+          slug='ui-wine-list-card'
+          title='Wine List Card Components'
+        />
       </div>
     </div>
   );

--- a/src/app/design-system/ui-wine-list-card/page.tsx
+++ b/src/app/design-system/ui-wine-list-card/page.tsx
@@ -1,0 +1,35 @@
+import dummyWineImage from '@/app/assets/images/dummy_wine_image.png';
+import WineListCard from '@/app/wines/components/WineListCard';
+
+export default function UiWineListCard() {
+  return (
+    <div className='p-8'>
+      <h1 className='mb-3 text-3xl font-bold text-gray-900'>Wine List Card</h1>
+
+      <h2 className='mt-10 mb-3 text-xl font-bold text-gray-700'>Example</h2>
+      <div className='flex flex-wrap gap-5'>
+        <WineListCard
+          country='Western Cape, South Africa'
+          image={dummyWineImage}
+          name='Sentinel Carbernet Sauvignon 2016'
+          rating={4.8}
+          recentReview='Cherry, cocoa, vanilla and clove - beautiful red fruit driven Amarone.
+          Low acidity and medium tannins. Nice long velvety finish.'
+          reviewCount={47}
+        />
+
+        <WineListCard
+          country='Western Cape, South Africa Western Cape, South Africa Western Cape, South Africa'
+          image={dummyWineImage}
+          name='Palazzo della Torre 2017 Palazzo della Torre 2017 Palazzo della Torre 2017 Palazzo della Torre 2017'
+          rating={4.8}
+          recentReview='Cherry, cocoa, vanilla and clove - beautiful red fruit driven Amarone.
+          Low acidity and medium tannins. Nice long velvety finish. Cherry, cocoa, vanilla and clove - beautiful red fruit driven Amarone.
+          Low acidity and medium tannins. Nice long velvety finish. Cherry, cocoa, vanilla and clove - beautiful red fruit driven Amarone.
+          Low acidity and medium tannins. Nice long velvety finish.'
+          reviewCount={47}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/wines/components/WineListCard.tsx
+++ b/src/app/wines/components/WineListCard.tsx
@@ -1,0 +1,90 @@
+import { StaticImageData } from 'next/image';
+
+import RatingSummary from '@/components/RatingSummary';
+import WineInfo from '@/components/WineInfo';
+
+interface WineListItemProps {
+  name: string;
+  country: string;
+  image: string | StaticImageData;
+  rating: number;
+  reviewCount: number;
+  recentReview?: string;
+}
+
+/**
+ * 와인 목록에서 사용되는 와인 카드 컴포넌트
+ *
+ * @description
+ * 와인의 기본 정보, 평점, 최신 후기를 카드 형태로 표시합니다.
+ * 반응형 디자인을 지원하며 모바일과 데스크탑에서 다른 레이아웃을 제공합니다.
+ *
+ * @component
+ * @param {string} props.name - 와인 이름
+ * @param {string} props.country - 와인 생산 국가
+ * @param {StaticImageData} props.image - 와인 이미지 데이터
+ * @param {number} props.rating - 와인 평점 (1-5)
+ * @param {number} props.reviewCount - 총 후기 개수
+ * @param {string} props.recentReview - 최신 후기 내용
+ *
+ * @example
+ * ```tsx
+ * <WineListCard
+ *   name="Château Margaux"
+ *   country="France"
+ *   image={wineImage}
+ *   rating={4.8}
+ *   reviewCount={47}
+ *   recentReview="정말 훌륭한 와인입니다. 깊은 맛과 향이 인상적이었어요."
+ * />
+ * ```
+ *
+ * @remarks
+ * - 모바일에서는 평점이 와인 정보의 아래로 배치됩니다.
+ * - 태블릿 이상에서는 평점이 오른쪽에 세로로 배치됩니다.
+ * - 와인 이름과 국가명, 최신 후기는 텍스트 길이에 따라 말줄임 처리됩니다.
+ */
+export default function WineListCard({
+  name,
+  country,
+  image,
+  rating,
+  reviewCount,
+  recentReview,
+}: WineListItemProps) {
+  return (
+    <div className='flex min-w-[25rem] flex-col overflow-hidden'>
+      <div className='relative flex flex-col gap-10 rounded-t-3xl border-1 border-gray-300 px-8 pt-10 sm:flex-row sm:justify-between'>
+        <WineInfo
+          price={64990}
+          priceClassName='text-[1.2rem] sm:text-[1.4rem]'
+          wineCountry={country}
+          wineCountryClassName='max-sm:text-[1.2rem] line-clamp-1 max-sm:mb-3'
+          wineImage={image}
+          wineImageClassName='h-[22rem]  w-[10rem] sm:w-[12rem]'
+          wineName={name}
+          wineNameClassName='text-[2rem] mb-2 sm:text-[2.7rem] md:text-[3rem] font-medium line-clamp-2 sm:line-clamp-3'
+        />
+
+        <RatingSummary
+          className='max-sm:absolute max-sm:bottom-[2rem] max-sm:left-[13rem] max-sm:flex-row'
+          rating={rating}
+          ratingClassName='max-sm:text-[2.5rem]'
+          size='sm'
+        >
+          <RatingSummary.Text className='max-sm:text-[1.2rem]'>
+            {reviewCount}개의 후기
+          </RatingSummary.Text>
+        </RatingSummary>
+      </div>
+      <div className='h-[11rem] w-full rounded-b-3xl border-1 border-t-0 border-gray-300 px-10 py-6'>
+        <p className='sub-content-text mb-3 font-semibold text-gray-800'>
+          최신 후기
+        </p>
+        <p className='sub-content-text line-clamp-3 text-gray-500 sm:line-clamp-2'>
+          {recentReview}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Badge/PriceBadge.tsx
+++ b/src/components/Badge/PriceBadge.tsx
@@ -6,11 +6,18 @@ import Badge from './Badge';
  *
  * @param props - PriceBadge 컴포넌트의 props
  * @param props.price - 표시할 가격 (숫자)
+ * @param props.className - 가격 문자열의 스타일 확장용 className
  * @returns 가격이 표시된 배지 JSX 요소
  */
-export default function PriceBadge({ price = 0 }: { price: number }) {
+export default function PriceBadge({
+  price = 0,
+  className,
+}: {
+  price: number;
+  className?: string;
+}) {
   return (
-    <Badge>
+    <Badge className={className}>
       <span>₩</span>
       <span>{price.toLocaleString('ko-KR')}</span>
     </Badge>

--- a/src/components/RatingSummary.tsx
+++ b/src/components/RatingSummary.tsx
@@ -4,6 +4,11 @@ import { cn } from '@/libs/cn';
 type Direction = 'row' | 'col';
 type Size = 'sm' | 'md' | 'lg';
 
+const DIRECTION_VARIANTS = {
+  row: 'items-center gap-[2rem]',
+  col: 'flex-col items-start gap-[1rem]',
+};
+
 const SIZE_VARIANTS = {
   lg: {
     rating: 'text-[5.4rem]',
@@ -69,27 +74,15 @@ function RatingSummary({
 }) {
   const ratingSize = SIZE_VARIANTS[size].rating;
 
-  // Stars(별점 아이콘)은 레이아웃 고정
-  const Content = (
-    <>
-      <Stars color={iconColor} rating={rating} size={size} />
-      {children}
-    </>
-  );
-
-  return direction === 'col' ? (
-    <div className={cn('flex flex-col items-start gap-[1rem]', className)}>
+  return (
+    <div className={cn(`flex ${DIRECTION_VARIANTS[direction]}`, className)}>
       <p className={cn(`font-bold ${ratingSize}`, ratingClassName)}>
         {rating.toFixed(1)}
       </p>
-      {Content}
-    </div>
-  ) : (
-    <div className={cn('flex items-center gap-[2rem]', className)}>
-      <p className={cn(`font-bold ${ratingSize}`, ratingClassName)}>
-        {rating.toFixed(1)}
-      </p>
-      <div className='flex flex-col items-start gap-[1rem]'>{Content}</div>
+      <div className='flex flex-col items-start gap-[0.5rem] sm:gap-[1rem]'>
+        <Stars color={iconColor} rating={rating} size={size} />
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/components/WineInfo.tsx
+++ b/src/components/WineInfo.tsx
@@ -11,7 +11,7 @@ interface WineInfoProps {
   /**
    * Next.js의 StaticImageData 타입의 와인 이미지
    */
-  wineImage: StaticImageData;
+  wineImage: StaticImageData | string;
   /**
    * 와인 생산 국가
    */
@@ -32,6 +32,10 @@ interface WineInfoProps {
    * 와인 이미지 스타일링을 위한 선택적 CSS 클래스명
    */
   wineImageClassName?: string;
+  /**
+   * 가격 배지 스타일링을 위한 선택적 CSS 클래스명
+   */
+  priceClassName?: string;
 }
 
 /**
@@ -40,12 +44,13 @@ interface WineInfoProps {
  * @component
  * @param {WineInfoProps} props -  컴포넌트 프로퍼티
  * @param {string} props.wineName - 표시할 와인 이름
- * @param {StaticImageData} props.wineImage - 와인 이미지 데이터
+ * @param {StaticImageData | string} props.wineImage - 와인 이미지 데이터
  * @param {string} props.wineCountry - 와인 생산 국가
  * @param {number} props.price - 와인 가격
  * @param {string} [props.wineNameClassName] - 와인 이름용 선택적 CSS 클래스
  * @param {string} [props.wineCountryClassName] - 와인 국가용 선택적 CSS 클래스
  * @param {string} [props.wineImageClassName] - 와인 이미지용 선택적 CSS 클래스
+ * @param {string} [props.priceClassName] - 가격 배지용 선택적 CSS 클래스
  *
  * @returns {JSX.Element} 와인 정보를 표시하는 JSX 요소
  *
@@ -70,15 +75,21 @@ export default function WineInfo({
   wineNameClassName,
   wineCountryClassName,
   wineImageClassName,
+  priceClassName,
 }: WineInfoProps) {
   return (
     <div className='flex'>
       <div className='flex h-full w-full gap-4'>
-        <div className='relative aspect-[3/4] w-full max-w-xs'>
+        <div
+          className={cn(
+            'relative aspect-[3/4] w-full max-w-xs',
+            wineImageClassName,
+          )}
+        >
           <Image
             fill
             alt='wine Image'
-            className={cn('object-contain', wineImageClassName)}
+            className='object-contain'
             src={wineImage}
           />
         </div>
@@ -91,7 +102,7 @@ export default function WineInfo({
           <p className={cn('text-md mb-5 text-gray-500', wineCountryClassName)}>
             {wineCountry}
           </p>
-          <PriceBadge price={price} />
+          <PriceBadge className={priceClassName} price={price} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 📌 관련 이슈

- #42

### 📋 작업 내용

- 와인 목록 페이지에서 검색 결과에 쓰일 Wine List Card 컴포넌트를 개발했습니다.
- 데스크탑, 태블릿, 모바일에서의 반응형 디자인을 적용했습니다.

**추가 변경사항**
1. PriceBadge 컴포넌트 
    - 가격 정보 span 태그의 스타일 확장을 위한 `className` prop 추가

2. WineInfo 컴포넌트
    - `wineImage` type에 string type 추가
    - `priceClassName` prop (string) 추가 : PriceBadge로 `className` prop을 전달하기 위해서 추가
    - `wineImageClassName`의 스타일 대상 변경 : 기존에는 Image 태그를 직접 스타일 확장 → wrapper div로 스타일 확장 대상 변경

3. RatingSummary 컴포넌트
    - 레이아웃 방향을 `derection` prop로 분기하고 있던 구조에서, 템플릿 리터럴을 통한 동적 스타일링 구조로 변경 (중복 코드를 줄이고 단순한 구조로 리팩토링 되었습니다.)

위 3가지 변경 사항은 현재 사용법에 최대한 영향이 가지 않도록 수정해보았습니다. 🛠️

### 📷 결과 및 스크린샷

|반응형|결과|
|-----|----|
|데스크탑|![image](https://github.com/user-attachments/assets/81139087-92c8-47ae-8af5-5bb7360503e3)|
|태블릿|![image](https://github.com/user-attachments/assets/725c229f-c8b9-4fe6-a998-4d9674fa9482)|
|모바일|![image](https://github.com/user-attachments/assets/cfedc338-94cf-428d-b3f5-f6f1d3ddb3ed)|




### 🔎 참고 (선택)
