### PR TITLE
[#76] feat: 와인 상세 페이지 UI

### DIFF
--- a/src/app/assets/icons/exclamation-mark.tsx
+++ b/src/app/assets/icons/exclamation-mark.tsx
@@ -1,0 +1,18 @@
+export default function ExclamationMark() {
+  return (
+    <svg
+      fill='none'
+      height='136'
+      viewBox='0 0 136 136'
+      width='136'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <rect fill='#F2F4F8' height='136' rx='68' width='136' />
+      <path
+        d='M57.3328 32.3197C57.1512 27.7797 60.7827 24 65.3264 24H70.6736C75.2173 24 78.8488 27.7797 78.6672 32.3197L76.6672 82.3197C76.4956 86.6102 72.9675 90 68.6736 90H67.3264C63.0325 90 59.5044 86.6102 59.3328 82.3197L57.3328 32.3197Z'
+        fill='white'
+      />
+      <rect fill='white' height='14' rx='7' width='18' x='59' y='98' />
+    </svg>
+  );
+}

--- a/src/app/design-system/ui-wine-details/page.tsx
+++ b/src/app/design-system/ui-wine-details/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+import Nothing from '@/app/wines/[wineId]/components/Nothing';
 import ReviewOverview from '@/app/wines/[wineId]/components/ReviewRating/ReviewOverview';
 import ReviewRange from '@/app/wines/[wineId]/components/ReviewRating/ReviewRange';
 import ReviewRangeGroup from '@/app/wines/[wineId]/components/ReviewRating/ReviewRangeGroup';
@@ -14,6 +16,7 @@ export default function UiWineDetail() {
       <ReviewRatingButton />
 
       <ReviewOverview data={REVIEW_RANGES} rating={4.8} reviewNumber={100} />
+      <Nothing />
     </div>
   );
 }

--- a/src/app/wines/[wineId]/components/Nothing.tsx
+++ b/src/app/wines/[wineId]/components/Nothing.tsx
@@ -1,0 +1,12 @@
+import ExclamationMark from '@/app/assets/icons/exclamation-mark';
+import Button from '@/components/Button';
+
+export default function Nothing() {
+  return (
+    <div className='flex flex-col items-center justify-center gap-4'>
+      <ExclamationMark />
+      <p className='text-sm text-gray-500'>작성된 리뷰가 없습니다.</p>
+      <Button onClick={() => {}}>리뷰 남기기</Button>
+    </div>
+  );
+}

--- a/src/app/wines/[wineId]/components/ReviewCard.tsx
+++ b/src/app/wines/[wineId]/components/ReviewCard.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import ChevronArrowIcon from '@/app/assets/icons/chevron-arrow';
 import HeartIcon from '@/app/assets/icons/heart';
 import VerticalMoreIcon from '@/app/assets/icons/vertical-more';
+import StarBadge from '@/components/Badge/StarBadge';
 import Dropdown from '@/components/Dropdown';
 import ProfileImg from '@/components/ProfileImg';
 import { formatToTimeAgo } from '@/libs/formmatToTimeago';
@@ -42,15 +43,21 @@ export default function ReviewCard() {
           </div>
         </div>
       </div>
-      <div className='flex items-center gap-2'>
-        {['체리', '오크', '카라멜', '시트러스', '꽃'].map((flavor) => (
-          <div
-            key={flavor}
-            className='w-fit rounded-full border border-gray-300 px-5 py-2 text-center text-lg text-gray-900'
-          >
-            {flavor}
-          </div>
-        ))}
+      <div className='flex items-center justify-between gap-2'>
+        <div
+          className='hide-scrollbar flex flex-1 items-center gap-2 overflow-x-scroll'
+          style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+        >
+          {['체리', '오크', '카라멜', '시트러스', '꽃'].map((flavor) => (
+            <div
+              key={flavor}
+              className='flex-shrink-0 rounded-full border border-gray-300 px-5 py-2 text-center text-lg text-gray-900'
+            >
+              {flavor}
+            </div>
+          ))}
+        </div>
+        <StarBadge className='text-2lg flex-shrink-0' rating={4.8} />
       </div>
       {isOpen && (
         <>

--- a/src/app/wines/[wineId]/components/ReviewRating/ReviewOverview.tsx
+++ b/src/app/wines/[wineId]/components/ReviewRating/ReviewOverview.tsx
@@ -13,10 +13,14 @@ export default function ReviewOverview({
   data: { label: string; value: number }[];
 }) {
   return (
-    <div className='flex flex-col gap-5'>
-      <ReviewRating rating={rating} reviewNumber={reviewNumber} />
-      <ReviewRangeGroup data={data} />
-      <ReviewRatingButton className='mt-10' />
+    <div className='flex flex-col gap-5 p-5 md:grid md:grid-cols-2 md:p-20 xl:flex xl:flex-col'>
+      <div className='flex justify-between gap-5 md:flex-col'>
+        <ReviewRating rating={rating} reviewNumber={reviewNumber} />
+        <ReviewRatingButton className='h-[4.2rem] md:mt-0 xl:mt-10' />
+      </div>
+      <div className='flex items-center'>
+        <ReviewRangeGroup data={data} />
+      </div>
     </div>
   );
 }

--- a/src/app/wines/[wineId]/page.tsx
+++ b/src/app/wines/[wineId]/page.tsx
@@ -1,21 +1,40 @@
-import ReviewCard from './components/ReviewCard';
+'use client';
+import wineImage from '@/app/assets/images/dummy_wine_image.png';
+import WineInfo from '@/components/WineInfo';
 
-export default async function WinePage({
-  params,
-}: {
-  params: Promise<{ wineId: string }>;
-}) {
-  const wineId = (await params).wineId;
-  console.log(wineId);
+import ReviewCard from './components/ReviewCard';
+import ReviewOverview from './components/ReviewRating/ReviewOverview';
+import { REVIEW_RANGES } from './dummy';
+
+export default function WinePage() {
   return (
-    <div>
-      <div />
-      <div className='grid grid-cols-6'>
-        <div className='col-span-4'>
-          <h3>리뷰 목록</h3>
-          <ReviewCard />
+    <div className='mt-10 flex w-full flex-col items-center'>
+      <div className='mb-40 grid w-full gap-10 rounded-2xl border border-gray-300 px-10 pt-20 md:grid-cols-4 xl:grid-cols-2'>
+        <WineInfo
+          className='md:col-span-3'
+          price={10000}
+          wineCountry='Western Cape, South Africa'
+          wineImage={wineImage}
+          wineName='Sentinel Cabernet Sauvignon 2016'
+        />
+      </div>
+
+      <div className='flex flex-col gap-10 xl:grid xl:grid-cols-6'>
+        <div className='order-2 col-span-1 xl:order-1 xl:col-span-4'>
+          <h3 className='mb-10 text-xl font-bold'>리뷰 목록</h3>
+          <div className='flex flex-col gap-5'>
+            {Array.from({ length: 10 }).map((_, index) => (
+              <ReviewCard key={index} />
+            ))}
+          </div>
         </div>
-        <div className='col-span-2'>별점 컴포넌트 들어가는 곳</div>
+        <div className='order-1 col-span-1 xl:order-2 xl:col-span-2'>
+          <ReviewOverview
+            data={REVIEW_RANGES}
+            rating={4.8}
+            reviewNumber={100}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/app/wines/[wineId]/page.tsx
+++ b/src/app/wines/[wineId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import wineImage from '@/app/assets/images/dummy_wine_image.png';
-import WineInfo from '@/components/WineInfo';
+import WineCard from '@/app/myprofile/components/Card/WineCard';
 
 import ReviewCard from './components/ReviewCard';
 import ReviewOverview from './components/ReviewRating/ReviewOverview';
@@ -9,7 +9,7 @@ import { REVIEW_RANGES } from './dummy';
 export default function WinePage() {
   return (
     <div className='mt-10 flex w-full flex-col items-center'>
-      <div className='mb-40 grid w-full gap-10 rounded-2xl border border-gray-300 px-10 pt-20 md:grid-cols-4 xl:grid-cols-2'>
+      {/* <div className='mb-40 grid w-full gap-10 rounded-2xl border border-gray-300 px-10 pt-20 md:grid-cols-4 xl:grid-cols-2'>
         <WineInfo
           className='md:col-span-3'
           price={10000}
@@ -17,7 +17,13 @@ export default function WinePage() {
           wineImage={wineImage}
           wineName='Sentinel Cabernet Sauvignon 2016'
         />
-      </div>
+      </div> */}
+      <WineCard
+        image={wineImage}
+        name='Sentinel Cabernet Sauvignon 2016'
+        price={10000}
+        region='Western Cape, South Africa'
+      />
 
       <div className='flex flex-col gap-10 xl:grid xl:grid-cols-6'>
         <div className='order-2 col-span-1 xl:order-1 xl:col-span-4'>

--- a/src/components/Badge/StarBadge.tsx
+++ b/src/components/Badge/StarBadge.tsx
@@ -2,9 +2,15 @@ import StarIcon from '@/app/assets/icons/star';
 
 import Badge from './Badge';
 
-export default function StarBadge({ rating }: { rating: number }) {
+export default function StarBadge({
+  rating,
+  className,
+}: {
+  rating: number;
+  className?: string;
+}) {
   return (
-    <Badge>
+    <Badge className={className}>
       <StarIcon filled color='#6a42db' />
       <span>{rating.toFixed(1)}</span>
     </Badge>

--- a/src/components/WineInfo.tsx
+++ b/src/components/WineInfo.tsx
@@ -38,10 +38,14 @@ interface WineInfoProps {
    * 와인 정보 컨테이너 스타일링을 위한 선택적 CSS 클래스명
    */
   className?: string;
-
+  /**
    * 가격 배지 스타일링을 위한 선택적 CSS 클래스명
    */
   priceClassName?: string;
+  /**
+   * 와인 정보 컨테이너 스타일링을 위한 선택적 CSS 클래스명
+   */
+  wineInfoClassName?: string;
 }
 
 /**
@@ -83,7 +87,6 @@ export default function WineInfo({
   wineImageClassName,
   className,
   priceClassName,
-
 }: WineInfoProps) {
   return (
     <div className={cn('flex', className)}>

--- a/src/components/WineInfo.tsx
+++ b/src/components/WineInfo.tsx
@@ -11,7 +11,7 @@ interface WineInfoProps {
   /**
    * Next.js의 StaticImageData 타입의 와인 이미지
    */
-  wineImage: StaticImageData;
+  wineImage: string | StaticImageData;
   /**
    * 와인 생산 국가
    */
@@ -32,6 +32,10 @@ interface WineInfoProps {
    * 와인 이미지 스타일링을 위한 선택적 CSS 클래스명
    */
   wineImageClassName?: string;
+  /**
+   * 와인 정보 컨테이너 스타일링을 위한 선택적 CSS 클래스명
+   */
+  className?: string;
 }
 
 /**
@@ -70,9 +74,10 @@ export default function WineInfo({
   wineNameClassName,
   wineCountryClassName,
   wineImageClassName,
+  className,
 }: WineInfoProps) {
   return (
-    <div className='flex'>
+    <div className={cn('flex', className)}>
       <div className='flex h-full w-full gap-4'>
         <div className='relative aspect-[3/4] w-full max-w-xs'>
           <Image


### PR DESCRIPTION
### 📌 관련 이슈

- #76 

### 📋 작업 내용

- 와인 상세 페이지 UI를 구현하였습니다.
- 데이터는 더미 데이터로 추후에 api에서 데이터를 불러와서 연결할 생각입니다.
- 아직 layout이 적용되기 전의 UI이므로 세세한 내용은 수정될 예정입니다.

### 📷 결과 및 스크린샷
- pc 화면
![image](https://github.com/user-attachments/assets/6e195b35-85e5-4591-a03e-2bfd73578c12)

- 테블릿 화면
![image](https://github.com/user-attachments/assets/be026a2e-7a27-481b-a27e-8fa386c83368)

- 모바일 화면
![image](https://github.com/user-attachments/assets/fa5876bd-92d4-4d5a-abc8-47908b623910)


### 🔎 참고 (선택)
- StarBadge의 사이즈 조절을 위해서 className props를 추가했습니다.