### PR TITLE
Feat/81 프로필 변경 모달 Form UI 및 기본 동작 구현

### DIFF
--- a/src/app/design-system/ui-inputfile/page.tsx
+++ b/src/app/design-system/ui-inputfile/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { StaticImageData } from 'next/image';
 import { useState } from 'react';
 
 import InputFile from '@/components/Inputs/InputFile';
 import ProfileImg from '@/components/ProfileImg';
 
 export default function UiInputFile() {
-  const [previewSrc, setPreviewSrc] = useState('');
+  const [previewSrc, setPreviewSrc] = useState<string | StaticImageData>('');
 
   return (
     <div className='p-8'>

--- a/src/app/design-system/ui-profile-change/page.tsx
+++ b/src/app/design-system/ui-profile-change/page.tsx
@@ -1,0 +1,9 @@
+import ProfileChangeFrom from '@/app/myprofile/components/ProfileChangeModal/ProfileChangeForm';
+
+export default function UiProfileChangeModalForm() {
+  return (
+    <div className='flex justify-center'>
+      <ProfileChangeFrom />
+    </div>
+  );
+}

--- a/src/app/myprofile/components/ProfileChangeModal/ProfileChangeForm.tsx
+++ b/src/app/myprofile/components/ProfileChangeModal/ProfileChangeForm.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+
+import DefaultImg from '@/app/assets/svgs/profile-default.svg';
+import Button from '@/components/Button';
+import InputFile from '@/components/Inputs/InputFile';
+import InputPair from '@/components/Inputs/InputPair';
+import ProfileImg from '@/components/ProfileImg';
+
+const user = {
+  name: 'WHYNE',
+};
+
+export default function ProfileChangeFrom() {
+  const [imgSrc, setImgSrc] = useState('');
+  const placeholder = user.name;
+
+  return (
+    <form className='flex flex-col items-center gap-[4rem]'>
+      <div className='flex flex-col items-center gap-[2rem]'>
+        <InputFile onChange={setImgSrc}>
+          <ProfileImg isSelectable size='lg' src={imgSrc || undefined} />
+        </InputFile>
+        <span className='text-md text-gray-500'>
+          {imgSrc === '' || imgSrc === DefaultImg
+            ? '프로필 사진 변경'
+            : '미리보기 이미지'}
+        </span>
+      </div>
+
+      <div className='flex flex-col items-end gap-8'>
+        <InputPair
+          inputClassName='w-full'
+          label='닉네임'
+          placeholder={placeholder}
+        />
+
+        <Button
+          className='text-[1rem]'
+          size='xs'
+          variant='ghost'
+          onClick={() => setImgSrc(DefaultImg)}
+        >
+          기본 이미지로 변경
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/myprofile/components/ProfileChangeModal/ProfileChangeForm.tsx
+++ b/src/app/myprofile/components/ProfileChangeModal/ProfileChangeForm.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { StaticImageData } from 'next/image';
 import { useState } from 'react';
 
 import DefaultImg from '@/app/assets/svgs/profile-default.svg';
+import MockImg from '@/app/design-system/ui-profileImg/mock-image/mock-img.png';
 import Button from '@/components/Button';
 import InputFile from '@/components/Inputs/InputFile';
 import InputPair from '@/components/Inputs/InputPair';
@@ -10,10 +12,11 @@ import ProfileImg from '@/components/ProfileImg';
 
 const user = {
   name: 'WHYNE',
+  image: MockImg,
 };
 
 export default function ProfileChangeFrom() {
-  const [imgSrc, setImgSrc] = useState('');
+  const [imgSrc, setImgSrc] = useState<string | StaticImageData>(user.image);
   const placeholder = user.name;
 
   return (
@@ -23,10 +26,29 @@ export default function ProfileChangeFrom() {
           <ProfileImg isSelectable size='lg' src={imgSrc || undefined} />
         </InputFile>
         <span className='text-md text-gray-500'>
-          {imgSrc === '' || imgSrc === DefaultImg
+          {imgSrc === user.image || imgSrc === DefaultImg
             ? '프로필 사진 변경'
             : '미리보기 이미지'}
         </span>
+        <div className='flex gap-[0.3rem]'>
+          <Button
+            className='text-[1rem]'
+            size='xs'
+            variant='ghost'
+            onClick={() => setImgSrc(DefaultImg)}
+          >
+            프로필 사진 삭제
+          </Button>
+
+          <Button
+            className='text-[1rem]'
+            size='xs'
+            variant='ghost'
+            onClick={() => setImgSrc(user.image)}
+          >
+            기존 이미지로 되돌리기
+          </Button>
+        </div>
       </div>
 
       <div className='flex flex-col items-end gap-8'>
@@ -35,15 +57,6 @@ export default function ProfileChangeFrom() {
           label='닉네임'
           placeholder={placeholder}
         />
-
-        <Button
-          className='text-[1rem]'
-          size='xs'
-          variant='ghost'
-          onClick={() => setImgSrc(DefaultImg)}
-        >
-          기본 이미지로 변경
-        </Button>
       </div>
     </form>
   );

--- a/src/app/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
+++ b/src/app/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
@@ -1,0 +1,1 @@
+export default function ProfileChangeModal() {}

--- a/src/components/Inputs/InputFile.tsx
+++ b/src/components/Inputs/InputFile.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { StaticImageData } from 'next/image';
 import { useRef } from 'react';
 
 import Input from './Input';
@@ -12,7 +13,7 @@ type NativeInputProps = Omit<
 interface InputFileProps extends NativeInputProps {
   label?: string;
   children: React.ReactNode;
-  onChange?: React.Dispatch<React.SetStateAction<string>>;
+  onChange?: React.Dispatch<React.SetStateAction<string | StaticImageData>>;
   accept?: string;
 }
 


### PR DESCRIPTION
### 📌 관련 이슈

- #81

### 📋 작업 내용

- **모달 구성 구조**

 ``` 
ProfileChangeModal
 ┣ ProfileChangeForm.tsx → 모달 content에 들어갈 form 컴포넌트
 ┗ ProfileChangeModal.tsx → 전체 모달 컴포넌트, content에는 ProfileChangeForm 포함 
 ```


- **주요 구현 사항**
  - 이미지 업로드 기능 구현
    - 파일 업로드 시 `imgSrc` 상태값 변경을 통해 미리보기 이미지 출력
  
  - 미리보기 텍스트 안내 기능 구현
    - 업로드된 이미지가 기존 이미지 또는 기본 이미지가 아닐 경우 `미리 보기 이미지` 문구 출력
    - 기본 이미지 또는 기존 이미지와 동일할 경우 `프로필 사진 변경` 문구 출력
  
  - 프로필 이미지 삭제 기능 구현
    - `프로필 사진 삭제` 버튼 클릭 시 기본 이미지(`DefaultImg`)로 변경
  
  - 기존 이미지 복원 기능 구현
    - `기존 이미지로 되돌리기` 버튼 클릭 시 원래 이미지(`user.image`)로 복원
  
  - 닉네임 입력 필드 추가
    - 기존 유저 이름을 placeholder로 설정하여 입력 유도

### 📷 결과 및 스크린샷

| 기존 이미지 | 기본 이미지 | 업로드한 이미지 |
|:-----------:|:-----------:|:----------------:|
| ![기존 이미지](https://github.com/user-attachments/assets/a884b104-82eb-4368-97f2-15c9e492376f) | ![기본 이미지](https://github.com/user-attachments/assets/91adb569-43c2-4eb5-ac44-535c9dbf7ae2) | ![업로드한 이미지](https://github.com/user-attachments/assets/2b5f99e7-247a-4d0e-83f8-207730d8d90f) |

<img src="https://github.com/user-attachments/assets/a42af15a-6289-4946-bae5-5b33f03b3f27" alt="프로필 이미지 변경 모달" width="800" />


### 🔎 참고 (선택)
- 헌재 단계에서는 UI 및 기본 동작 구현만 해놓은 상태입니다. 
- 추후 이미지 저장 기능은 API 연동 로직을 통해 추가할 예정입니다!

- gif 를 첨부해두긴 했지만, 화질이 좋지않아 preview 링크에서 확인하시는게 나을 것 같습니다!

- preview에서는 `/design-system/ui-profile-change` 경로로 접속하시면 확인 가능할 것 같습니다.

- 디자인... 어렵습니다 ㅎㅎ 디자인 관련 피드백은 남겨주시면 바로 수정하겠습니다!
