### PR TITLE
global.css의 오타 수정

### DIFF
--- a/src/app/design-system/ui-modal/page.tsx
+++ b/src/app/design-system/ui-modal/page.tsx
@@ -45,7 +45,7 @@ export default function UiModal() {
         <hr className='my-6 border-gray-200' />
 
         <p className='font-bold text-black'>🧩 기본 사용 예시</p>
-        <pre className='bg-white p-4 text-sm text-gray-800'>
+        <pre className='overflow-scroll bg-white p-4 text-sm text-gray-800'>
           {`<Modal>
   <ModalTrigger>모달 열기</ModalTrigger>
   <ModalContent>
@@ -61,7 +61,7 @@ export default function UiModal() {
         </pre>
 
         <p className='mt-6 font-bold text-black'>🧩 asChild 패턴 사용 예시</p>
-        <pre className='bg-white p-4 text-sm text-gray-800'>
+        <pre className='overflow-scroll bg-white p-4 text-sm text-gray-800'>
           {`<Modal>
   <ModalTrigger asChild>
     <Button size='sm' variant='secondary'>열기</Button>
@@ -81,7 +81,7 @@ export default function UiModal() {
         </pre>
 
         <p className='mt-6 font-bold text-black'>🧩 제어 모달 사용 예시</p>
-        <pre className='bg-white p-4 text-sm text-gray-800'>
+        <pre className='overflow-scroll bg-white p-4 text-sm text-gray-800'>
           {`<Modal externalIsOpen={isOpen} onExternalChange={setIsOpen}>
   <Modal.Trigger>열기</Modal.Trigger>
   <Modal.Content>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,17 +112,17 @@
 @layer utilities {
   .scrollbar-thin {
     scrollbar-width: thin;
+  }
 
-    .range-slider {
-      @apply absolute -top-[0.6rem] h-2 w-full appearance-none bg-transparent md:-top-[0.7rem];
-      pointer-events: none;
-    }
+  .range-slider {
+    @apply absolute -top-[0.6rem] h-2 w-full appearance-none bg-transparent md:-top-[0.7rem];
+    pointer-events: none;
+  }
 
-    .range-slider::-webkit-slider-thumb {
-      @apply size-6 rounded-full border-1 border-gray-300 bg-white hover:size-7 hover:bg-gray-50 md:size-8 md:hover:size-9;
-      -webkit-appearance: none;
-      pointer-events: auto;
-      cursor: pointer;
-    }
+  .range-slider::-webkit-slider-thumb {
+    @apply size-6 rounded-full border-1 border-gray-300 bg-white hover:size-7 hover:bg-gray-50 md:size-8 md:hover:size-9;
+    -webkit-appearance: none;
+    pointer-events: auto;
+    cursor: pointer;
   }
 }


### PR DESCRIPTION
### 📌 관련 이슈

- #91

### 📋 작업 내용

- 양방향 range input의 스타일이 깨지는 오류가 발생했습니다.
- `global.css`에서 오타가 발생했던 것이 원인으로, 수정했습니다.

### 📷 결과 및 스크린샷

**오류 상황**
![image](https://github.com/user-attachments/assets/09c95b4a-24cc-4269-9fef-fdaa5e97e5fc)

**해결**
![image](https://github.com/user-attachments/assets/07fa9462-a52c-4c8f-b797-4d9ac0b6a2fa)


### 🔎 참고 (선택)
