### PR TITLE
Feat/110 와인 등록/수정 모달 API 연동 및 검증 로직 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.77.0",
     "axios": "^1.9.0",
     "clsx": "^2.1.1",
+    "form-data": "^4.0.3",
     "framer-motion": "^12.12.2",
     "next": "15.1.8",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      form-data:
+        specifier: ^4.0.3
+        version: 4.0.3
       framer-motion:
         specifier: ^12.12.2
         version: 12.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2104,10 +2107,10 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  form-data@4.0.2:
+  form-data@4.0.3:
     resolution:
       {
-        integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==,
+        integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==,
       }
     engines: { node: '>= 6' }
 
@@ -4785,7 +4788,7 @@ snapshots:
   axios@1.9.0:
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.2
+      form-data: 4.0.3
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -5395,11 +5398,12 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.2:
+  form-data@4.0.3:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   framer-motion@12.16.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):

--- a/src/app/api/action/wine-action.ts
+++ b/src/app/api/action/wine-action.ts
@@ -1,0 +1,48 @@
+'use server';
+
+import { createPrivateServerInstance } from '@/apis/privateServerInstance';
+
+type WineFormData = {
+  id?: number;
+  name: string;
+  region: string;
+  image: string | File;
+  price: number;
+  type: string;
+};
+
+/**
+ * 와인 데이터 등록 또는 수정 서버 액션
+ *
+ * 클라이언트에서 전달받은 와인 정보를 기반으로
+ * - 새로운 와인을 등록하거나
+ * - 기존 와인을 수정합니다.
+ *
+ * ⚠️ FormData가 아닌 일반 객체를 받아 처리합니다.
+ *    (이미지 업로드는 클라이언트 측에서 처리되어 URL로 전달됨)
+ *
+ * @param {WineFormData} data - 와인 정보
+ */
+export async function WineData(data: WineFormData) {
+  const axios = await createPrivateServerInstance();
+
+  const { data: user } = await axios
+    .get('/users/me')
+    .catch(() => ({ data: null }));
+  if (!user) throw new Error('로그인 정보가 없습니다.');
+
+  const payload = {
+    name: data.name,
+    region: data.region,
+    image: data.image,
+    price: Number(data.price),
+    type: data.type,
+  };
+
+  // id가 있으면 PATCH (수정), 없으면 POST (등록)
+  if (data.id) {
+    await axios.patch(`/wines/${data.id}`, payload);
+  } else {
+    await axios.post('/wines', payload);
+  }
+}

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -1,0 +1,78 @@
+import axios, { AxiosError } from 'axios';
+import FormData from 'form-data'; // node 전용 form-data
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { Readable } from 'stream';
+
+import { ServerErrorResponse } from '@/types/error';
+
+/**
+ * 이미지 업로드 (POST)
+ *
+ * 클라이언트에서 업로드된 파일을 받아 외부 API 서버(`/images/upload`)에 전달하고,
+ * 응답을 그대로 클라이언트에 반환합니다.
+ *
+ * - 최대 5MB 이하 파일만 허용
+ * - 확장자를 유지한 채 파일명을 타임스탬프로 변경
+ *
+ */
+export async function POST(req: Request) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  try {
+    // 클라이언트로부터 formData 파싱
+    const formData = await req.formData();
+    const file = formData.get('file') as File;
+
+    if (!file) {
+      return NextResponse.json(
+        { error: '파일이 존재하지 않습니다.' },
+        { status: 400 },
+      );
+    }
+
+    // 브라우저 File → Node.js Buffer 변환
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    //  업로드 파일 크기 제한 (5MB 초과 시 오류 반환)
+    const form = new FormData();
+    if (file.size > 5 * 1024 * 1024) {
+      return NextResponse.json(
+        { error: '5MB 이하 파일만 업로드 가능합니다.' },
+        { status: 400 },
+      );
+    }
+
+    // 파일 확장자 유지한 새로운 파일명 생성 (타임스탬프 기반)
+    // 서버 저장 시 기존 파일명과 충돌 방지 및 고유성 확보를 위해 업로드 시점의 timestamp를 파일명으로 사용
+    const ext = file.name.split('.').pop();
+    const safeFileName = `${Date.now()}.${ext}`;
+
+    form.append('image', Readable.from(buffer), {
+      filename: safeFileName,
+      contentType: file.type,
+    });
+
+    // API 서버에 이미지 업로드 요청
+    const res = await axios.post(
+      `${process.env.NEXT_PUBLIC_API_SERVER_URL}/images/upload`,
+      form,
+      {
+        headers: {
+          ...form.getHeaders(), // form-data가 Content-Type과 boundary를 포함한 헤더를 자동 생성
+          Authorization: accessToken ? `Bearer ${accessToken}` : undefined,
+        },
+      },
+    );
+
+    return NextResponse.json(res.data);
+  } catch (err) {
+    const error = err as AxiosError<ServerErrorResponse>;
+    const message = error.response?.data?.error || '유저 정보 조회 실패';
+    const status = error.response?.status || 500;
+
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/src/app/design-system/wine-modify-test/page.tsx
+++ b/src/app/design-system/wine-modify-test/page.tsx
@@ -1,0 +1,47 @@
+import { createPrivateServerInstance } from '@/apis/privateServerInstance';
+import WineCard from '@/app/myprofile/components/Card/WineCard';
+import Tab from '@/app/myprofile/components/Tab';
+
+interface Wine {
+  id: number;
+  name: string;
+  image: string;
+  price: number;
+  region: string;
+  rating: number;
+  type: string;
+}
+
+export default async function Wines() {
+  const axios = await createPrivateServerInstance();
+
+  const { data } = await axios.get('/users/me/wines', {
+    params: {
+      limit: 10,
+    },
+  });
+
+  const wines = data.list;
+
+  if (!Array.isArray(wines) || wines.length === 0) {
+    return (
+      <div>
+        <Tab totalCount={0} />
+        <div className='mt-[5rem] flex items-center justify-center'>
+          <div>등록된 와인이 없습니다</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex flex-col'>
+      <Tab totalCount={data.totalCount} />
+      <div className='flex flex-col gap-10'>
+        {wines.map((wine: Wine) => (
+          <WineCard key={wine.id} className='cursor-pointer' wine={wine} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/myprofile/components/Card/CardDropdown.tsx
+++ b/src/app/myprofile/components/Card/CardDropdown.tsx
@@ -1,19 +1,39 @@
 'use client';
+import { useState } from 'react';
+
 import VerticalMoreIcon from '@/app/assets/icons/vertical-more';
 import Dropdown from '@/components/Dropdown';
+import WineModal from '@/components/Modals/WineModal/WineModal';
+interface Wine {
+  id: number;
+  name: string;
+  region: string;
+  image: string;
+  price: number;
+  type: string;
+}
 
-export default function CardDropdown() {
-  const handleModify = () => console.log('수정');
+export default function CardDropdown({ wine }: { wine: Wine }) {
+  const [wineIsOpen, setWineIsOpen] = useState(false);
   const handleDelete = () => console.log('삭제');
   return (
-    <Dropdown>
-      <Dropdown.Trigger>
-        <VerticalMoreIcon />
-      </Dropdown.Trigger>
-      <Dropdown.Menu>
-        <Dropdown.Item onClick={handleModify}>수정하기</Dropdown.Item>
-        <Dropdown.Item onClick={handleDelete}>삭제하기</Dropdown.Item>
-      </Dropdown.Menu>
-    </Dropdown>
+    <>
+      <Dropdown>
+        <Dropdown.Trigger>
+          <VerticalMoreIcon />
+        </Dropdown.Trigger>
+        <Dropdown.Menu>
+          <Dropdown.Item onClick={() => setWineIsOpen(true)}>
+            수정하기
+          </Dropdown.Item>
+          <Dropdown.Item onClick={handleDelete}>삭제하기</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+      <WineModal
+        isOpen={wineIsOpen}
+        setIsOpen={setWineIsOpen}
+        wineData={wine}
+      />
+    </>
   );
 }

--- a/src/app/myprofile/components/Card/WineCard.tsx
+++ b/src/app/myprofile/components/Card/WineCard.tsx
@@ -1,4 +1,4 @@
-import Image, { StaticImageData } from 'next/image';
+import Image from 'next/image';
 
 import PriceBadge from '@/components/Badge/PriceBadge';
 import { cn } from '@/libs/cn';
@@ -6,10 +6,14 @@ import { cn } from '@/libs/cn';
 import CardDropdown from './CardDropdown';
 
 interface WineCardProps {
-  name: string;
-  region: string;
-  image: string | StaticImageData;
-  price: number;
+  wine: {
+    id: number;
+    name: string;
+    region: string;
+    image: string;
+    price: number;
+    type: string;
+  };
   className?: string;
   isDropdown?: boolean;
 }
@@ -25,10 +29,7 @@ interface WineCardProps {
  * @param {boolean} [props.isDropdown=true] - 드롭다운 메뉴 표시 여부
  */
 export default function WineCard({
-  name,
-  region,
-  image,
-  price,
+  wine,
   className,
   isDropdown = true,
 }: WineCardProps) {
@@ -40,20 +41,22 @@ export default function WineCard({
       )}
     >
       <div className='absolute bottom-0 left-[2.5rem] h-[18rem] w-[5.3rem] md:-top-17 md:left-[3.5rem] md:h-[27rem] md:w-[8rem]'>
-        <Image fill alt={name} className='object-cover' src={image} />
+        <Image fill alt={wine.name} className='object-cover' src={wine.image} />
       </div>
       <div className='ml-[8rem] flex h-full w-[19rem] flex-col justify-center gap-y-2 md:ml-[14rem] md:w-[30rem] md:gap-y-5'>
         <h1 className='text-[2rem] font-bold text-gray-800 md:text-[3rem]'>
-          {name}
+          {wine.name}
         </h1>
-        <h2 className='text-[1.3rem] text-gray-500 md:text-lg'>{region}</h2>
+        <h2 className='text-[1.3rem] text-gray-500 md:text-lg'>
+          {wine.region}
+        </h2>
         <div className='mt-2'>
-          <PriceBadge price={price} />
+          <PriceBadge price={wine.price} />
         </div>
       </div>
       {isDropdown && (
         <div className='absolute top-12 right-5 md:top-15 md:right-10 xl:right-15'>
-          <CardDropdown />
+          <CardDropdown wine={wine} />
         </div>
       )}
     </article>

--- a/src/app/wines/components/ReviewActionButton.tsx
+++ b/src/app/wines/components/ReviewActionButton.tsx
@@ -1,18 +1,23 @@
 'use client';
 
+import { useState } from 'react';
+
 import Button from '@/components/Button';
+import WineModal from '@/components/Modals/WineModal/WineModal';
 
 export default function ReviewActionButton() {
+  const [isOpen, setIsOpen] = useState(false);
   return (
     <section className='fixed bottom-0 left-0 z-20 flex h-[8rem] w-full items-center justify-center border-t-1 border-gray-100 bg-white md:relative md:z-auto md:col-start-3 md:col-end-4 md:row-start-2 md:row-end-3 md:h-full md:w-[20rem] md:border-none xl:hidden'>
       <Button
         className='h-[5rem] w-[90vw] md:h-full md:w-full'
         round='rounded'
         variant='primary'
-        onClick={() => console.log('button')}
+        onClick={() => setIsOpen(true)}
       >
         와인 등록하기
       </Button>
+      <WineModal isOpen={isOpen} setIsOpen={setIsOpen} />
     </section>
   );
 }

--- a/src/app/wines/components/ReviewActionButton.tsx
+++ b/src/app/wines/components/ReviewActionButton.tsx
@@ -8,16 +8,20 @@ import WineModal from '@/components/Modals/WineModal/WineModal';
 export default function ReviewActionButton() {
   const [isOpen, setIsOpen] = useState(false);
   return (
-    <section className='fixed bottom-0 left-0 z-20 flex h-[8rem] w-full items-center justify-center border-t-1 border-gray-100 bg-white md:relative md:z-auto md:col-start-3 md:col-end-4 md:row-start-2 md:row-end-3 md:h-full md:w-[20rem] md:border-none xl:hidden'>
-      <Button
-        className='h-[5rem] w-[90vw] md:h-full md:w-full'
-        round='rounded'
-        variant='primary'
-        onClick={() => setIsOpen(true)}
-      >
-        와인 등록하기
-      </Button>
+    <>
+      <section className='fixed bottom-0 left-0 z-20 flex h-[8rem] w-full items-center justify-center border-t-1 border-gray-100 bg-white md:relative md:z-auto md:col-start-3 md:col-end-4 md:row-start-2 md:row-end-3 md:h-full md:w-[20rem] md:border-none xl:hidden'>
+        <Button
+          className='h-[5rem] w-[90vw] md:h-full md:w-full'
+          round='rounded'
+          variant='primary'
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        >
+          와인 등록하기
+        </Button>
+      </section>
       <WineModal isOpen={isOpen} setIsOpen={setIsOpen} />
-    </section>
+    </>
   );
 }

--- a/src/app/wines/components/WineFilterSidebar.tsx
+++ b/src/app/wines/components/WineFilterSidebar.tsx
@@ -14,6 +14,7 @@ import {
   ModalTitle,
   ModalTrigger,
 } from '@/components/Modal';
+import WineModal from '@/components/Modals/WineModal/WineModal';
 
 import Filter from './Filter';
 
@@ -23,20 +24,26 @@ import Filter from './Filter';
  * @description 데스크탑에서 보여지는 검색 조건 필터링 패널
  */
 function DesktopFilterPanel({ filterState, onFilterChange }) {
+  const [isOpen, setIsOpen] = useState(false);
   return (
-    <div className='sticky top-30 mt-30 flex h-[30rem] w-full flex-col gap-16 max-xl:hidden'>
-      <Filter filterState={filterState} onFilterChange={onFilterChange} />
+    <>
+      <div className='sticky top-30 mt-30 flex h-[30rem] w-full flex-col gap-16 max-xl:hidden'>
+        <Filter filterState={filterState} onFilterChange={onFilterChange} />
 
-      <Button
-        className='w-full'
-        round='rounded'
-        size='sm'
-        variant='primary'
-        onClick={() => {}}
-      >
-        와인 등록하기
-      </Button>
-    </div>
+        <Button
+          className='w-full'
+          round='rounded'
+          size='sm'
+          variant='primary'
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        >
+          와인 등록하기
+        </Button>
+      </div>
+      <WineModal isOpen={isOpen} setIsOpen={setIsOpen} />
+    </>
   );
 }
 

--- a/src/components/Inputs/InputFile.tsx
+++ b/src/components/Inputs/InputFile.tsx
@@ -12,7 +12,7 @@ type NativeInputProps = Omit<
 interface InputFileProps extends NativeInputProps {
   label?: string;
   children: React.ReactNode;
-  onChange?: (fileUrl: string) => void;
+  onChange?: (file: File) => void;
   accept?: string;
 }
 
@@ -22,7 +22,7 @@ interface InputFileProps extends NativeInputProps {
  * 커스텀 트리거 요소를 클릭하여 파일을 선택하고,
  * 선택된 파일의 URL을 상위 컴포넌트로 전달합니다.
  *
- *  @param {string} [label] - input의 라벨 텍스트. `id`, `name`에도 함께 사용됨
+ * @param {string} [label] - input의 라벨 텍스트. `id`, `name`에도 함께 사용됨
  * @param {React.ReactNode} children - 클릭 가능한 커스텀 트리거 요소
  * @param {(fileUrl: string | null) => void} [onChange] - 파일 선택 시 호출되는 함수 URL 또는 null 반환
  * @param {string} [accept] - 업로드 가능한 파일의 MIME 타입 (기본값: "image/*")
@@ -48,10 +48,10 @@ export default function InputFile({
     inputRef.current?.click();
   };
 
+  // 파일 객체만 상위로 전달하고, 미리보기 및 업로드 처리는 상위에서 직접 하도록 책임 분리
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] ?? null;
-    const url = file ? URL.createObjectURL(file) : '';
-    onChange?.(url);
+    const file = e.target.files?.[0];
+    if (file) onChange?.(file);
   };
 
   return (

--- a/src/components/Modals/WineModal/WineForm.tsx
+++ b/src/components/Modals/WineModal/WineForm.tsx
@@ -97,23 +97,27 @@ export default function WineForm({ wineData }: { wineData?: WineFormData }) {
         value={!hasInputChanged.region ? '' : formData.region}
         onChange={handleChange('region')}
       />
-      <SelectBox
-        label='타입'
-        options={OPTIONS}
-        onChange={(value) => setFormData((prev) => ({ ...prev, type: value }))}
-        {...(isEdit && { value: wineData.type })}
-      >
-        <SelectBox.Trigger triggerClassName='w-full' />
-        <SelectBox.Options>
-          {OPTIONS.map((opt) => (
-            <SelectBox.Option key={opt} value={opt}>
-              <div className='hover:bg-primary-10 hover:text-primary-100 mx-[0.6rem] my-2 flex h-[3.6rem] w-[31.5] items-center rounded-[1.2rem] md:h-[4rem] md:w-[38rem]'>
-                <span className='ml-[1.6em]'>{opt}</span>
-              </div>
-            </SelectBox.Option>
-          ))}
-        </SelectBox.Options>
-      </SelectBox>
+      <div className='relative w-full'>
+        <SelectBox
+          label='타입'
+          options={OPTIONS}
+          onChange={(value) =>
+            setFormData((prev) => ({ ...prev, type: value }))
+          }
+          {...(isEdit && { value: wineData.type })}
+        >
+          <SelectBox.Trigger triggerClassName='w-full' />
+          <SelectBox.Options>
+            {OPTIONS.map((opt) => (
+              <SelectBox.Option key={opt} value={opt}>
+                <div className='hover:bg-primary-10 hover:text-primary-100 mx-[0.6rem] my-2 flex h-[3.6rem] w-full items-center rounded-[1.2rem] px-2 py-2 md:h-[4rem]'>
+                  <span className='ml-[1.6em]'>{opt}</span>
+                </div>
+              </SelectBox.Option>
+            ))}
+          </SelectBox.Options>
+        </SelectBox>
+      </div>
       <InputFile
         label='와인 사진'
         onChange={(value: string) =>

--- a/src/components/Modals/WineModal/WineModal.tsx
+++ b/src/components/Modals/WineModal/WineModal.tsx
@@ -1,1 +1,44 @@
-export default function WineModal() {}
+import Button from '@/components/Button';
+import Modal from '@/components/Modal/Modal';
+import ModalBody from '@/components/Modal/ModalBody';
+import ModalClose from '@/components/Modal/ModalClose';
+import ModalContent from '@/components/Modal/ModalContent';
+import ModalFooter from '@/components/Modal/ModalFooter';
+import ModalHeader from '@/components/Modal/ModalHeader';
+import ModalTitle from '@/components/Modal/ModalTitle';
+
+import WineForm from './WineForm';
+
+export default function WineModal({
+  isOpen,
+  setIsOpen,
+}: {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
+  return (
+    <Modal externalIsOpen={isOpen} onExternalChange={setIsOpen}>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>와인 등록</ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+          <WineForm />
+        </ModalBody>
+        <ModalFooter>
+          <ModalClose />
+          <ModalClose asChild>
+            <Button variant='secondary' onClick={() => {}}>
+              취소
+            </Button>
+          </ModalClose>
+          <ModalClose asChild>
+            <Button variant='primary' onClick={() => {}}>
+              등록하기
+            </Button>
+          </ModalClose>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/Modals/WineModal/WineModal.tsx
+++ b/src/components/Modals/WineModal/WineModal.tsx
@@ -1,3 +1,9 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { WineData } from '@/app/api/action/wine-action';
 import Button from '@/components/Button';
 import Modal from '@/components/Modal/Modal';
 import ModalBody from '@/components/Modal/ModalBody';
@@ -6,24 +12,126 @@ import ModalContent from '@/components/Modal/ModalContent';
 import ModalFooter from '@/components/Modal/ModalFooter';
 import ModalHeader from '@/components/Modal/ModalHeader';
 import ModalTitle from '@/components/Modal/ModalTitle';
+import useUserStore from '@/stores/Auth-store/authStore';
 
-import WineForm from './WineForm';
+import WineForm, { WineFormData } from './WineForm';
 
+const DEFAULT_DATA: WineFormData = {
+  name: '',
+  region: '',
+  image: '',
+  price: 0,
+  type: '',
+};
+
+/**
+ * WineModal 컴포넌트
+ *
+ * 와인 정보를 등록하거나 수정할 수 있는 모달 UI를 제공합니다.
+ * 사용자 인증 상태 확인, 필수 입력 검증, 변경 여부 확인,
+ * WineData 서버 액션 호출 등을 처리합니다.
+ *
+ * @param {boolean} isOpen - 모달 열림 상태
+ * @param {React.Dispatch<React.SetStateAction<boolean>>} setIsOpen - 모달 열림 상태 변경 함수
+ * @param {WineFormData} [wineData] - 수정 시 기존 와인 데이터 (없으면 등록으로 간주)
+ */
 export default function WineModal({
   isOpen,
   setIsOpen,
+  wineData,
 }: {
   isOpen: boolean;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  wineData?: WineFormData;
 }) {
+  const router = useRouter();
+  const user = useUserStore((state) => state.user);
+
+  // 폼 입력 상태: 초기값은 수정 모드면 wineData, 등록 모드면 빈 값
+  const [formData, setFormData] = useState<WineFormData>(
+    wineData ?? DEFAULT_DATA,
+  );
+  const [isLoading, setIsLoading] = useState(false);
+
+  /**
+   * 폼 제출 핸들러
+   * - 로그인 여부 확인
+   * - 입력값 누락 여부 확인
+   * - 수정 시 변경사항 존재 여부 확인
+   * - WineData 액션 호출 및 성공/실패 처리
+   * - 로딩 상태 관리
+   */
+  const handleSubmit = async () => {
+    if (!user) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
+
+    const { name, region, image, price, type } = formData;
+
+    if (!name || !region || !image || !price || !type) {
+      alert('모든 값을 입력해주세요.');
+      return;
+    }
+
+    if (wineData) {
+      const isUnchanged =
+        wineData.name === name &&
+        wineData.region === region &&
+        wineData.image === image &&
+        wineData.price === price &&
+        wineData.type === type;
+
+      if (isUnchanged) {
+        alert('변경된 사항이 없습니다.');
+        return;
+      }
+    }
+
+    try {
+      setIsLoading(true);
+
+      const payload = {
+        name: formData.name,
+        region: formData.region,
+        image: formData.image,
+        price: Number(formData.price),
+        type: formData.type,
+        ...(formData.id && { id: formData.id }), // PATCH용 id
+      };
+
+      await WineData(payload);
+
+      alert(
+        wineData
+          ? '와인이 성공적으로 수정되었습니다.'
+          : '와인이 성공적으로 등록되었습니다.',
+      );
+      setIsOpen(false);
+
+      // 수정/등록 후 페이지 새로고침
+      router.push(wineData ? '/myprofile/wines' : '/wines');
+      router.refresh();
+    } catch (err) {
+      console.error('Wine 등록/수정 오류:', err);
+      alert(
+        wineData
+          ? '와인 수정 중 오류가 발생했습니다.'
+          : '와인 등록 중 오류가 발생했습니다.',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return (
     <Modal externalIsOpen={isOpen} onExternalChange={setIsOpen}>
       <ModalContent className='xl:max-w-[50rem]'>
         <ModalHeader>
-          <ModalTitle>와인 등록</ModalTitle>
+          <ModalTitle>{wineData ? '와인 수정' : '와인 등록'}</ModalTitle>
         </ModalHeader>
         <ModalBody>
-          <WineForm />
+          <WineForm wineData={wineData} onChange={setFormData} />
         </ModalBody>
         <ModalFooter>
           <ModalClose />
@@ -32,23 +140,24 @@ export default function WineModal({
               <ModalClose asChild>
                 <Button
                   className='w-[10.8rem] md:w-[9rem] xl:w-[10rem]'
+                  disabled={isLoading}
                   variant='secondary'
-                  onClick={() => {}}
+                  onClick={() => setIsOpen(false)}
                 >
                   취소
                 </Button>
               </ModalClose>
             </div>
             <div>
-              <ModalClose asChild>
-                <Button
-                  className='w-[27rem] md:w-[24rem] xl:w-[35rem]'
-                  variant='primary'
-                  onClick={() => {}}
-                >
-                  등록하기
-                </Button>
-              </ModalClose>
+              <Button
+                className='w-[27rem] md:w-[24rem] xl:w-[35rem]'
+                variant='primary'
+                onClick={() => {
+                  handleSubmit();
+                }}
+              >
+                {isLoading ? '처리 중...' : wineData ? '수정하기' : '등록하기'}
+              </Button>
             </div>
           </div>
         </ModalFooter>

--- a/src/components/Modals/WineModal/WineModal.tsx
+++ b/src/components/Modals/WineModal/WineModal.tsx
@@ -18,7 +18,7 @@ export default function WineModal({
 }) {
   return (
     <Modal externalIsOpen={isOpen} onExternalChange={setIsOpen}>
-      <ModalContent>
+      <ModalContent className='xl:max-w-[50rem]'>
         <ModalHeader>
           <ModalTitle>와인 등록</ModalTitle>
         </ModalHeader>
@@ -27,16 +27,30 @@ export default function WineModal({
         </ModalBody>
         <ModalFooter>
           <ModalClose />
-          <ModalClose asChild>
-            <Button variant='secondary' onClick={() => {}}>
-              취소
-            </Button>
-          </ModalClose>
-          <ModalClose asChild>
-            <Button variant='primary' onClick={() => {}}>
-              등록하기
-            </Button>
-          </ModalClose>
+          <div className='flex w-full justify-between'>
+            <div className='w-[3rem]'>
+              <ModalClose asChild>
+                <Button
+                  className='w-[10.8rem] md:w-[9rem] xl:w-[10rem]'
+                  variant='secondary'
+                  onClick={() => {}}
+                >
+                  취소
+                </Button>
+              </ModalClose>
+            </div>
+            <div>
+              <ModalClose asChild>
+                <Button
+                  className='w-[27rem] md:w-[24rem] xl:w-[35rem]'
+                  variant='primary'
+                  onClick={() => {}}
+                >
+                  등록하기
+                </Button>
+              </ModalClose>
+            </div>
+          </div>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/src/components/SelectBox/SelectBox.Option.tsx
+++ b/src/components/SelectBox/SelectBox.Option.tsx
@@ -33,7 +33,7 @@ export default function Option({
   children,
 }: OptionProps) {
   const optionClasses = cn(
-    ' h-auto w-[32.7rem] cursor-pointer  px-4 py-3 text-lg font-medium text-gray-800 md:w-[41.2rem]',
+    ' h-auto w-full cursor-pointer px-4 py-3 text-lg font-medium text-gray-800',
     optionClassName,
   );
   const { setSelected, onChange, close } = useSelectedBoxContext();

--- a/src/components/SelectBox/SelectBox.Options.tsx
+++ b/src/components/SelectBox/SelectBox.Options.tsx
@@ -33,7 +33,7 @@ export default function Options({ children, optionsClassName }: OptionsProps) {
   return (
     <ul
       className={cn(
-        'scrollbar-thin absolute z-10 mt-2 max-h-[30rem] w-[32.7rem] overflow-x-hidden overflow-y-auto rounded-[1.6rem] border border-gray-300 bg-white md:w-[41.2rem]',
+        'scrollbar-thin absolute z-10 mt-2 max-h-[30rem] w-full overflow-x-hidden overflow-y-auto rounded-[1.6rem] border border-gray-300 bg-white',
         optionsClassName,
       )}
     >

--- a/src/components/SelectBox/SelectBox.Trigger.tsx
+++ b/src/components/SelectBox/SelectBox.Trigger.tsx
@@ -31,7 +31,7 @@ export default function Trigger({ triggerClassName, children }: TriggerProps) {
       aria-expanded={isOpen}
       aria-haspopup='listbox'
       className={cn(
-        'flex h-auto min-h-[4.2rem] min-w-[32.7rem] cursor-pointer items-center justify-between rounded-[1.6rem] border border-gray-300 px-[2rem] text-lg md:min-h-[4.8rem] md:w-[41.2rem]',
+        'flex h-auto min-h-[4.2rem] w-full cursor-pointer items-center justify-between rounded-[1.6rem] border border-gray-300 px-[2rem] text-lg md:min-h-[4.8rem]',
         hasChanged ? 'text-gray-800' : 'text-gray-500',
         triggerClassName,
       )}

--- a/src/types/error.ts
+++ b/src/types/error.ts
@@ -4,3 +4,7 @@ export interface ErrorFallbackProps {
   title?: string;
   description?: string;
 }
+
+export type ServerErrorResponse = {
+  error?: string;
+};


### PR DESCRIPTION
### 📌 관련 이슈

- #110 

### 📋 작업 내용

### 와인 등록/수정 모달(WineModal) 구성
- `WineModal` 컴포넌트를 통해 와인을 등록하거나 수정할 수 있도록 구현
- 모달 구조:
  - `ModalHeader`: "와인 등록" 또는 "와인 수정" 제목
  - `ModalBody`: 와인 입력 폼(`WineForm`) 포함
  - `ModalFooter`: 취소 / 등록(또는 수정) 버튼
- 제어 컴포넌트로 구성되어 있으먀 외부에서 `isOepn`상태에 따라 열리고 닫힘


## 예외 처리 로직

모달 내에서는 아래와 같은 사용자 입력 및 서버 응답에 대한 예외 처리를 수행합니다.

1. **비로그인 사용자**
   - `/users/me` API로 로그인 상태 확인
   - 로그인하지 않은 경우
     `alert("로그인이 필요합니다.")` 후 서버 요청 중단

2. **입력 누락 확인**
   - name, region, image, price, type 중 하나라도 비어 있으면
     `alert("모든 값을 입력해주세요.")`

3. **수정 시 기존 값과 동일**
   - 수정 모드에서 기존 데이터와 모두 동일하면
     `alert("변경된 사항이 없습니다.")`

4. **가격 입력 제한**
   - 숫자 이외 입력 제거
   - 100만원 초과 입력 시
     `alert("100만원 이하만 입력 가능합니다.")` 후 입력 초기화

5. **이미지 업로드 실패**
   - 서버 업로드 실패 시
     `alert("이미지 업로드에 실패했습니다.")`

6. **서버 액션 실패 처리**
   - 등록/수정 중 오류 발생 시
     `alert("와인 등록/수정 중 오류가 발생했습니다.")` 메시지 출력

7. 정상적으로 요청이 전송되었을 시 
    - `alert("와인 등록/수정에 성공했습니다.") 메세지 출력 후
    - 페이지 새로고침 수행
      - 와인 수정 : `/myprofile/wines`
      - 와인 등록 : `/wines`
    

##  서버 액션: `WineData`

- `FormData`가 아닌 **일반 객체**로 와인 데이터를 서버에 전달
  - 전달 받은 객체에서 와인 `id`가 존재하면 `PATCH /wines/{id}`
  - 없으면 `POST /wines`


##  이미지 업로드 API (`/api/images/upload`)

- `FormData`를 사용한 별도 API 라우트에서 처리
- 브라우저의 `File` 객체를 Node.js 환경에서 사용할 수 있도록 `Buffer`로 변환
- 파일명은 `timestamp` 기반으로 생성 → **이름 충돌 방지**
- `form.getHeaders()` 사용 → `Content-Type`과 boundary 자동 포함

### 📷 결과 및 스크린샷

### 와인 등록
https://github.com/user-attachments/assets/9eb5911c-a35f-4eac-8a77-f009fe87ee8d

### 와인 수정
https://github.com/user-attachments/assets/15928361-4b26-4bfb-9d5c-cba90d44892a



### 🔎 참고 (선택)

- 파일 이미지 업로드를 위해 `from-data` 모듈을 설치했습니다.
- 해당 PR이 머지 된 후에 pull 받으시고 pnpm install 한 번 해주셔야 합니다!