### PR TITLE
[#128] refactor: 3차 QA 내용 반영 및 무한 스크롤

### DIFF
--- a/src/app/api/wines/[id]/route.ts
+++ b/src/app/api/wines/[id]/route.ts
@@ -11,7 +11,12 @@ export const GET = async (
   const { id } = await params;
   const cookieStore = await cookies();
   const accessToken = cookieStore.get('accessToken')?.value;
-  console.log(`api route wine 쿠키 : ${accessToken} `);
+
+  // 페이지네이션 파라미터 추출하기
+  const searchParams = request.nextUrl.searchParams;
+  console.log('searchParams', searchParams);
+  const page = parseInt(searchParams.get('page') || '1');
+  const limit = parseInt(searchParams.get('limit') || '5');
 
   try {
     const response = await axios.get(
@@ -23,11 +28,30 @@ export const GET = async (
       },
     );
     const data = response.data;
+    const reviews = data.reviews || [];
 
-    return NextResponse.json(data);
+    //페이지네이션 처리
+    const startIndex = (page - 1) * limit;
+    const endIndex = page * limit;
+    const paginatedReviews = reviews.slice(startIndex, endIndex);
+
+    //페이지네이션 메타데이터 추가
+    const totalReviews = reviews.length;
+    const hasNextPage = endIndex < totalReviews;
+    const nextPage = hasNextPage ? page + 1 : null;
+
+    //응답 데이터터
+    return NextResponse.json({
+      ...data,
+      currentPage: page,
+      reviews: paginatedReviews,
+      totalPages: Math.ceil(totalReviews / limit),
+      totalReviews,
+      hasNextPage,
+      nextPage,
+    });
   } catch (err) {
     const error = err as AxiosError<ServerErrorResponse>;
-
     const message = error.response?.data?.error || '와인 상세 데이터 조회실패';
     const status = error.response?.status || 500;
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,18 +11,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ko'>
-<body className='overflow-x-hidden'>
-    <header className='mx-auto w-full max-w-[350rem] px-[5vw] md:px-[10vw] xl:px-[15vw]'>
-      <Header />
-    </header>
-    <main className='mx-auto my-10 w-full max-w-[350rem] px-[5vw] md:px-[10vw] xl:px-[15vw]'>
-      <QueryProvider>{children}</QueryProvider>
-    </main>
-    <footer>
-      <Footer />
-    </footer>
-    <div id='modal-root' />
-  </body>
+      <body>
+        <DynamicLayout>
+          <main className='mx-auto my-10 w-full max-w-[350rem] px-[5vw] md:px-[10vw] xl:px-[15vw]'>
+            <QueryProvider>{children}</QueryProvider>
+          </main>
+        </DynamicLayout>
+        <div id='modal-root' />
+      </body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,7 @@ export default function RootLayout({
     <html lang='ko'>
       <body>
         <DynamicLayout>
-          <main className='mx-auto my-10 w-full max-w-[350rem] px-[5vw] md:px-[10vw] xl:px-[15vw]'>
+          <main className='mx-auto my-10 min-h-screen w-full max-w-[350rem] px-[5vw] md:px-[10vw] xl:px-[15vw]'>
             <QueryProvider>{children}</QueryProvider>
           </main>
         </DynamicLayout>

--- a/src/app/wines/[wineId]/components/AromaAnalysis/AromaAnalysis.tsx
+++ b/src/app/wines/[wineId]/components/AromaAnalysis/AromaAnalysis.tsx
@@ -6,28 +6,19 @@ import { analyzeAromaData } from './utils';
  * 와인 향 분석 컴포넌트
  *
  * @param reviews - 리뷰 데이터
- * @param totalReviews - 총 리뷰 수
  */
 
 interface AromaAnalysisProps {
   reviews: ReviewType[];
-  totalReviews?: number;
 }
 
-export default function AromaAnalysis({
-  reviews,
-  totalReviews = 0,
-}: AromaAnalysisProps) {
+export default function AromaAnalysis({ reviews }: AromaAnalysisProps) {
   const topAromas = analyzeAromaData(reviews);
-  const reviewCount = totalReviews || reviews.length;
 
   return (
     <div className='w-full'>
       <div className='mb-6 flex items-center justify-between'>
         <h3 className='text-xl font-bold text-gray-900'>어떤 향이 있나요?</h3>
-        <span className='text-sm text-gray-500'>
-          ({reviewCount ?? 0}개 리뷰)
-        </span>
       </div>
 
       {topAromas.length > 0 ? (
@@ -37,8 +28,10 @@ export default function AromaAnalysis({
           ))}
         </div>
       ) : (
-        <div className='flex h-32 items-center justify-center rounded-2xl border border-gray-300 bg-gray-50'>
-          <p className='text-gray-500'>아직 향에 대한 리뷰가 없습니다.</p>
+        <div className='flex h-32 items-center justify-center rounded-2xl'>
+          <p className='text-md text-gray-500'>
+            아직 향에 대한 리뷰가 없습니다.
+          </p>
         </div>
       )}
     </div>

--- a/src/app/wines/[wineId]/components/Nothing.tsx
+++ b/src/app/wines/[wineId]/components/Nothing.tsx
@@ -4,7 +4,7 @@ import Button from '@/components/Button';
 export default function Nothing() {
   return (
     <div className='flex flex-col items-center justify-center gap-4'>
-      <ExclamationMark />
+      <ExclamationMark className='size-[10rem]' />
       <p className='text-sm text-gray-500'>작성된 리뷰가 없습니다.</p>
       <Button onClick={() => {}}>리뷰 남기기</Button>
     </div>

--- a/src/app/wines/[wineId]/components/ReviewCard.tsx
+++ b/src/app/wines/[wineId]/components/ReviewCard.tsx
@@ -10,8 +10,8 @@ import Dropdown from '@/components/Dropdown';
 import InputRange from '@/components/InputRange';
 import ProfileImg from '@/components/ProfileImg';
 import { cn } from '@/libs/cn';
-import { formatToTimeAgo } from '@/libs/formmatToTimeago';
 import useUserStore from '@/stores/Auth-store/authStore';
+import { getTimeAgo } from '@/utils/getTimeAgo';
 
 import { ReviewType } from '../types';
 import { AromaType } from './AromaAnalysis/types';
@@ -82,9 +82,7 @@ export default function ReviewCard({ review }: { review: ReviewType }) {
           <ProfileImg className='size-[4.2rem]' size='md' />
           <div className='flex flex-col justify-center'>
             <p className='text-lg font-bold'>{user.nickname}</p>
-            <p className='text-md text-gray-500'>
-              {formatToTimeAgo(createdAt)}
-            </p>
+            <p className='text-md text-gray-500'>{getTimeAgo(createdAt)}</p>
           </div>
         </div>
         <div className='flex items-center gap-2 pt-2'>

--- a/src/app/wines/[wineId]/components/ReviewCard.tsx
+++ b/src/app/wines/[wineId]/components/ReviewCard.tsx
@@ -14,6 +14,8 @@ import { formatToTimeAgo } from '@/libs/formmatToTimeago';
 import useUserStore from '@/stores/Auth-store/authStore';
 
 import { ReviewType } from '../types';
+import { AromaType } from './AromaAnalysis/types';
+import { getAromaLabel } from './AromaAnalysis/utils';
 
 export default function ReviewCard({ review }: { review: ReviewType }) {
   const [isOpen, setIsOpen] = useState(true);
@@ -76,11 +78,11 @@ export default function ReviewCard({ review }: { review: ReviewType }) {
   return (
     <div className='relative flex flex-col gap-5 rounded-2xl border border-gray-300 p-10'>
       <div className='flex items-start justify-between'>
-        <div className='flex gap-5'>
-          <ProfileImg size='md' />
+        <div className='flex items-center gap-5'>
+          <ProfileImg className='size-[4.2rem]' size='md' />
           <div className='flex flex-col justify-center'>
-            <p className='text-2lg font-bold'>{user.nickname}</p>
-            <p className='text-lg text-gray-500'>
+            <p className='text-lg font-bold'>{user.nickname}</p>
+            <p className='text-md text-gray-500'>
               {formatToTimeAgo(createdAt)}
             </p>
           </div>
@@ -117,13 +119,13 @@ export default function ReviewCard({ review }: { review: ReviewType }) {
           {aroma.map((flavor) => (
             <div
               key={flavor}
-              className='flex-shrink-0 rounded-full border border-gray-300 px-5 py-2 text-center text-lg text-gray-900'
+              className='text-md flex-shrink-0 rounded-full border border-gray-300 px-5 py-2 text-center text-gray-900'
             >
-              {flavor}
+              {getAromaLabel(flavor as AromaType)}
             </div>
           ))}
         </div>
-        <StarBadge className='text-2lg flex-shrink-0' rating={rating} />
+        <StarBadge className='flex-shrink-0' rating={rating} />
       </div>
       <div
         className={cn(

--- a/src/app/wines/[wineId]/components/ReviewRating/ReviewRange.tsx
+++ b/src/app/wines/[wineId]/components/ReviewRating/ReviewRange.tsx
@@ -1,9 +1,11 @@
 export default function ReviewRange({
   label,
   value,
+  span,
 }: {
   label: string;
   value: number;
+  span: number;
 }) {
   // 0~5 범위를 0~100% 비율로 변환
   const percentage = (value / 5) * 100;
@@ -12,6 +14,7 @@ export default function ReviewRange({
     <div className='flex h-fit w-full items-center gap-3'>
       <label className='text-sm leading-none whitespace-nowrap text-gray-500'>
         {label}
+        <p className='text-[1rem] text-gray-500'>{`(${span}개)`}</p>
       </label>
       <div className='relative h-3 w-full overflow-hidden rounded-lg bg-gray-200'>
         <div

--- a/src/app/wines/[wineId]/components/ReviewRating/ReviewRangeGroup.tsx
+++ b/src/app/wines/[wineId]/components/ReviewRating/ReviewRangeGroup.tsx
@@ -5,7 +5,6 @@ export default function ReviewRangeGroup({
 }: {
   data: Record<string, number>;
 }) {
-  console.log('data', data);
   return (
     <div className='flex w-full flex-col gap-6'>
       {Object.entries(data).map(([key, value]) => (

--- a/src/app/wines/[wineId]/components/ReviewRating/ReviewRangeGroup.tsx
+++ b/src/app/wines/[wineId]/components/ReviewRating/ReviewRangeGroup.tsx
@@ -5,13 +5,15 @@ export default function ReviewRangeGroup({
 }: {
   data: Record<string, number>;
 }) {
+  console.log('data', data);
   return (
     <div className='flex w-full flex-col gap-6'>
-      {[5, 4, 3, 2, 1].map((score) => (
+      {Object.entries(data).map(([key, value]) => (
         <ReviewRange
-          key={score}
-          label={`${score}점`}
-          value={data[score] || 0}
+          key={key}
+          label={`${key}점`}
+          span={value}
+          value={value || 0}
         />
       ))}
     </div>

--- a/src/app/wines/[wineId]/components/flavorAnalysis/FlavorAnalysis.tsx
+++ b/src/app/wines/[wineId]/components/flavorAnalysis/FlavorAnalysis.tsx
@@ -17,11 +17,8 @@ export default function FlavorAnalysis({ data = [] }: { data: ReviewType[] }) {
     <div className='w-full'>
       <div className='mb-6 flex items-center justify-between'>
         <h3 className='text-xl font-bold text-gray-900'>어떤 맛이 있나요?</h3>
-        <span className='text-sm text-gray-500'>
-          ({(!data || data.length) ?? 0}개 리뷰)
-        </span>
       </div>
-      <div>
+      <div className='w-full'>
         <InputRange disabled values={values} />
       </div>
     </div>

--- a/src/app/wines/[wineId]/page.tsx
+++ b/src/app/wines/[wineId]/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { privateInstance } from '@/apis/privateInstance';
 import dummyWineImage from '@/app/assets/images/dummy_wine_image.png';
 import WineCard from '@/app/myprofile/components/Card/WineCard';
+import { cn } from '@/libs/cn';
 import useUserStore from '@/stores/Auth-store/authStore';
 
 import AromaAnalysis from './components/AromaAnalysis/AromaAnalysis';
@@ -45,7 +46,7 @@ export default function WinePage() {
         region={wineInfo?.region || 'Western Cape, South Africa'}
       />
 
-      <div className='mt-10 grid w-full grid-cols-2 gap-10'>
+      <div className='my-15 grid w-full grid-cols-1 gap-10 xl:grid-cols-2 xl:gap-20'>
         <div className='col-span-1 w-full'>
           <FlavorAnalysis data={wineInfo?.reviews as ReviewType[]} />
         </div>
@@ -55,8 +56,20 @@ export default function WinePage() {
       </div>
 
       <div className='flex w-full flex-col gap-10 xl:grid xl:grid-cols-6'>
-        <div className='order-2 col-span-1 w-full xl:order-1 xl:col-span-4'>
-          <h3 className='mt-10 mb-10 text-xl font-bold'>리뷰 목록</h3>
+        <div
+          className={cn(
+            'order-2 col-span-1 w-full xl:order-1',
+            wineInfo?.reviews && wineInfo?.reviews.length > 0
+              ? 'xl:col-span-4'
+              : 'xl:col-span-6',
+          )}
+        >
+          <div className='flex items-center justify-between'>
+            <h3 className='mt-10 mb-10 text-xl font-bold'>리뷰 목록</h3>
+            <span className='text-sm text-gray-500'>
+              {wineInfo?.reviews.length}개 리뷰
+            </span>
+          </div>
           {wineInfo?.reviews && wineInfo?.reviews.length > 0 ? (
             <div className='flex flex-col gap-5'>
               {wineInfo?.reviews.map((review) => (
@@ -69,15 +82,15 @@ export default function WinePage() {
             </div>
           )}
         </div>
-        {wineInfo?.reviews && wineInfo?.reviews.length > 0 && (
-          <div className='order-1 col-span-1 xl:order-2 xl:col-span-2'>
+        {wineInfo?.reviews && wineInfo?.reviews.length > 0 ? (
+          <div className='col-span1 order-1 xl:order-2 xl:col-span-2'>
             <ReviewOverview
               data={wineInfo.avgRatings}
               rating={wineInfo.avgRating || 0}
               reviewNumber={totalReviews}
             />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/app/wines/[wineId]/page.tsx
+++ b/src/app/wines/[wineId]/page.tsx
@@ -89,7 +89,7 @@ export default function WinePage() {
         region={wineInfo?.region || 'Western Cape, South Africa'}
       />
 
-      <div className='my-15 grid w-full grid-cols-1 gap-10 xl:grid-cols-2 xl:gap-20'>
+      <div className='mt-24 mb-15 grid w-full grid-cols-1 gap-10 xl:grid-cols-2 xl:gap-20'>
         <div className='col-span-1 w-full'>
           <FlavorAnalysis data={wineInfo?.reviews as ReviewType[]} />
         </div>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/libs/cn';
 
 const BASIC_CLASSNAME =
-  'text-primary-100 bg-primary-100/10 flex w-fit items-center gap-2 rounded-xl px-3 py-2 text-[1.8rem] font-bold';
+  'text-primary-100 bg-primary-100/10 flex w-fit items-center gap-2 rounded-xl px-3 py-2 text-[1.4rem] md:text-[1.6rem] xl:text-[1.8rem] font-bold';
 
 /**
  * Props for the Badge component

--- a/src/components/InputRange.tsx
+++ b/src/components/InputRange.tsx
@@ -98,8 +98,8 @@ export default function InputRange({
             {item.rightText}
           </span>
           {/* 현재 값 표시 */}
-          <span className='ml-2 w-fit text-center text-xs font-semibold text-gray-400'>
-            {values[item.name as keyof Option]}점
+          <span className='ml-2 max-w-fit text-center text-[1rem] font-semibold text-gray-400 md:text-xs'>
+            {values[item.name as keyof Option].toFixed(1)}점
           </span>
         </div>
       ))}

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -24,7 +24,7 @@ export function RangeSlider({
   ...props
 }: RangeSliderProps) {
   return (
-    <div className={cn('max-w-[491px] min-w-0 flex-1', containerClassName)}>
+    <div className={cn('w-full min-w-0 flex-1', containerClassName)}>
       {label && (
         <label className='sr-only' htmlFor={id || name}>
           {label}

--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -12,6 +12,7 @@ const BASIC_CLASSNAME =
 interface RangeSliderProps extends Omit<React.ComponentProps<'input'>, 'type'> {
   label?: string;
   containerClassName?: string;
+  disabled?: boolean;
 }
 
 export function RangeSlider({
@@ -21,6 +22,7 @@ export function RangeSlider({
   id,
   value,
   name,
+  disabled,
   ...props
 }: RangeSliderProps) {
   return (
@@ -31,7 +33,11 @@ export function RangeSlider({
         </label>
       )}
       <input
-        className={cn(BASIC_CLASSNAME, className)}
+        className={cn(
+          BASIC_CLASSNAME,
+          className,
+          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+        )}
         id={id}
         name={name}
         type='range'


### PR DESCRIPTION
### 📌 관련 이슈

- #128 

### 📋 작업 내용

**QA 내용**

- 태그 한글로 변경
- 리뷰 총 개수 한 개로 통일하기
- 맛 분석 / 향 분석 사이 공간 , 문 분석 영역 위 아래 공간 넓히기
- 맛/향 분석 컴포넌트 반응형 구현하기
- ~~animate:bounce를 ref를 사용해서 card에 hover했을 때 화살표 bounce되도록 설정~~ (이건 추후에)

- 리뷰 카드 수정
유저 정보 영역 좀 더 작게
시간 formatter 사용하기
tag 크기 작게 수정
본문 위, 아래 여백 주기
inputRange width-full로 주기

- RatingInputGroup 점수 마다 개수 보이도록 수정
- 리뷰 없을 때 나오는 이미지 중앙 정렬 되도록 수정
- 리뷰 없을 때 나오는 이미지 느낌표 크기 줄이기
- 향 없을 때 배경색과 테두리 없애기

**무한 스크롤 구현**

- route.ts에서 받아온 데이터를 가공해서 클라이언트에 넘겨주도록 구현.

### 📷 결과 및 스크린샷
리뷰 카드
![image](https://github.com/user-attachments/assets/bfa0652e-42dc-48fd-a4cd-b2be1f474ef8)

- 전체적
![image](https://github.com/user-attachments/assets/98f88612-b239-457b-9daa-3f3cb6f48bbb)

- 반응형
![image](https://github.com/user-attachments/assets/ae0f61f1-5635-4131-b9b7-25a582714cdc)
![image](https://github.com/user-attachments/assets/07695c57-e7f0-402f-b0e8-a6da2ce5ae39)

- 리뷰가 없을 때 
![image](https://github.com/user-attachments/assets/f9991668-d287-4386-95bd-26293fb5b21c)



### 🔎 참고 (선택)
