### PR TITLE
3차 QA사항수정/카카오 로그인시 로딩컴포넌트추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,18 +11,15 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ko'>
-<body className='overflow-x-hidden'>
-    <header className='mx-auto w-full max-w-[350rem] px-[5vw] md:px-[10vw] xl:px-[15vw]'>
-      <Header />
-    </header>
-    <main className='mx-auto my-10 w-full max-w-[350rem] px-[5vw] md:px-[10vw] xl:px-[15vw]'>
-      <QueryProvider>{children}</QueryProvider>
-    </main>
-    <footer>
-      <Footer />
-    </footer>
-    <div id='modal-root' />
-  </body>
+      <body>
+        <DynamicLayout>
+          <main className='mx-auto my-10 w-full max-w-[350rem] px-[5vw] md:px-[10vw] xl:px-[15vw]'>
+            <QueryProvider>{children}</QueryProvider>
+          </main>
+        </DynamicLayout>
+
+        <div id='modal-root' />
+      </body>
     </html>
   );
 }

--- a/src/app/login/components/LoginForm.tsx
+++ b/src/app/login/components/LoginForm.tsx
@@ -69,7 +69,7 @@ export default function LoginForm() {
   };
 
   return (
-    <div className='flex min-h-screen items-center justify-center px-4 py-12'>
+    <div className='flex min-h-screen items-center justify-center bg-white px-4 py-12'>
       <div className='w-full max-w-3xl space-y-8 rounded-xl bg-white p-6 shadow-2xl inset-shadow-sm inset-shadow-gray-200 sm:p-8'>
         <div className='py-8 text-center'>
           <Link aria-label='홈으로 이동' href='/'>
@@ -123,7 +123,7 @@ export default function LoginForm() {
             </div>
 
             {isPending ? (
-              <div className='mt-7 flex items-center justify-center'>
+              <div className='mt-[4rem] flex items-center justify-center'>
                 <Button
                   loading
                   className='w-full'
@@ -135,7 +135,7 @@ export default function LoginForm() {
                 </Button>
               </div>
             ) : (
-              <div className='mt-7 flex items-center justify-center'>
+              <div className='mt-[4rem] flex items-center justify-center'>
                 <Button
                   className='w-full'
                   disabled={isDisabled}
@@ -148,7 +148,7 @@ export default function LoginForm() {
               </div>
             )}
 
-            <div className='mt-5 flex items-center justify-center'>
+            <div className='mt-[2rem] flex items-center justify-center'>
               <Button
                 className='w-full bg-yellow-300'
                 round='rounded'

--- a/src/app/login/components/LoginForm.tsx
+++ b/src/app/login/components/LoginForm.tsx
@@ -122,31 +122,19 @@ export default function LoginForm() {
               />
             </div>
 
-            {isPending ? (
-              <div className='mt-[4rem] flex items-center justify-center'>
-                <Button
-                  loading
-                  className='w-full'
-                  size='lg'
-                  type='submit'
-                  onClick={() => {}}
-                >
-                  로그인중
-                </Button>
-              </div>
-            ) : (
-              <div className='mt-[4rem] flex items-center justify-center'>
-                <Button
-                  className='w-full'
-                  disabled={isDisabled}
-                  size='lg'
-                  type='submit'
-                  onClick={() => {}}
-                >
-                  로그인
-                </Button>
-              </div>
-            )}
+            <div className='mt-[4rem] flex items-center justify-center'>
+              <Button
+                className='w-full'
+                disabled={isDisabled}
+                loading={isPending}
+                size='lg'
+                type='submit'
+                variant='primary'
+                onClick={() => {}}
+              >
+                로그인
+              </Button>
+            </div>
 
             <div className='mt-[2rem] flex items-center justify-center'>
               <Button

--- a/src/app/oauth/kakao/components/KakaoLoading.tsx
+++ b/src/app/oauth/kakao/components/KakaoLoading.tsx
@@ -1,0 +1,12 @@
+export default function KakaoLoading() {
+  return (
+    <div className='flex min-h-screen items-center justify-center bg-white'>
+      <div className='flex flex-col items-center'>
+        <div className='mb-6 h-16 w-16 animate-spin rounded-full border-4 border-yellow-300 border-t-transparent' />
+        <p className='mt-4 text-lg font-semibold text-gray-700'>
+          카카오 로그인 처리 중...
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -7,6 +7,8 @@ import { useEffect } from 'react';
 
 import useUserStore from '@/stores/Auth-store/authStore';
 
+import KakaoLoading from './components/KakaoLoading';
+
 export default function KakaoCallbackPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -36,5 +38,5 @@ export default function KakaoCallbackPage() {
     }
   }, [searchParams, router]);
 
-  return <div>로그인중...</div>;
+  return <KakaoLoading />;
 }

--- a/src/app/signup/components/SignupForm.tsx
+++ b/src/app/signup/components/SignupForm.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import React from 'react';
 import { useEffect, useState } from 'react';
 import { useActionState } from 'react';
 
@@ -164,7 +165,7 @@ export default function SignUpForm() {
             </div>
 
             {isPending ? (
-              <div className='mt-7 flex items-center justify-center'>
+              <div className='mt-[4rem] flex items-center justify-center'>
                 <Button
                   loading
                   className='w-full'
@@ -176,7 +177,7 @@ export default function SignUpForm() {
                 </Button>
               </div>
             ) : (
-              <div className='mt-10 flex items-center justify-center'>
+              <div className='mt-[4rem] flex items-center justify-center'>
                 <Button
                   className='w-full'
                   disabled={isDisabled}

--- a/src/app/signup/components/SignupForm.tsx
+++ b/src/app/signup/components/SignupForm.tsx
@@ -164,32 +164,19 @@ export default function SignUpForm() {
               />
             </div>
 
-            {isPending ? (
-              <div className='mt-[4rem] flex items-center justify-center'>
-                <Button
-                  loading
-                  className='w-full'
-                  size='lg'
-                  type='submit'
-                  onClick={() => {}}
-                >
-                  회원가입중
-                </Button>
-              </div>
-            ) : (
-              <div className='mt-[4rem] flex items-center justify-center'>
-                <Button
-                  className='w-full'
-                  disabled={isDisabled}
-                  size='lg'
-                  type='submit'
-                  onClick={() => {}}
-                >
-                  회원가입
-                </Button>
-              </div>
-            )}
-
+            <div className='mt-[4rem] flex items-center justify-center'>
+              <Button
+                className='w-full'
+                disabled={isDisabled}
+                loading={isPending}
+                size='lg'
+                type='submit'
+                variant='primary'
+                onClick={() => {}}
+              >
+                회원가입
+              </Button>
+            </div>
             <div className='mt-[4rem] flex items-center justify-center'>
               <div className='h-px flex-grow bg-gray-500' />
               <span className='text-md mx-4 flex-shrink text-gray-600'>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ import ProfileImg from './ProfileImg';
 
 export default function Header() {
   const router = useRouter();
-  const user = useUserStore((state) => state.user);
+  const { user, hasHydrated } = useUserStore();
 
   const logout = useLogout();
   const setUser = useUserStore((state) => state.setUser);
@@ -27,6 +27,16 @@ export default function Header() {
     }
   };
 
+  //플리커링 방지를 위해 하이드레이션이 완료되기 전에는 이부분을 렌더링
+  if (!hasHydrated) {
+    return (
+      <header className='mt-7 h-[5rem] animate-pulse rounded-2xl bg-[#101318] text-white md:h-[7rem]'>
+        <div className='flex h-full items-center justify-between px-[4rem] md:px-[8rem]'>
+          <div className='flex space-x-6' />
+        </div>
+      </header>
+    );
+  }
   return (
     <div>
       <header className='mt-7 h-[5rem] rounded-2xl bg-[#101318] text-white md:h-[7rem]'>


### PR DESCRIPTION
### 📌 관련 이슈

- #127 

### 📋 작업 내용

- QA사항 피드백내용 적용
- 카카오 로그인시 리다이렉트페이지에 로딩이 나타나도록 컴포넌트 추가


### 📷 결과 및 스크린샷

-

### 🔎 참고 (선택)

!!!로그인/회원가입페이지 bg변경은 라우트 그룹 적용한뒤에 수정하도록 하겠습니다. (layout의 콘텐츠영역 제한이 적용되는 이슈)