### PR TITLE
추천 와인 api 재연결

### DIFF
--- a/src/app/api/wines/revalidate-recommended-wines/route.ts
+++ b/src/app/api/wines/revalidate-recommended-wines/route.ts
@@ -1,0 +1,10 @@
+import { revalidateTag } from 'next/cache';
+
+/**
+ * @description
+ * 추천 와인 캐시를 무효화하는 POST 요청입니다.
+ */
+export async function POST() {
+  revalidateTag('recommended-wines');
+  return new Response('Revalidated', { status: 200 });
+}

--- a/src/app/wines/components/WineRecommendationSection.tsx
+++ b/src/app/wines/components/WineRecommendationSection.tsx
@@ -1,62 +1,53 @@
-import { unstable_cache } from 'next/cache';
+import { ApiErrorClass } from '@/libs/errors/apis/ApiError';
+import { useRecommendedWineStore } from '@/stores/recommendedWines';
+import { ApiErrorResponse } from '@/types/apiErrorResponse';
 
-import { Wine } from '../types';
 import RecommendedWineItem from './RecommendedWineItem';
 
-/**
- * @param array 아이템 리스트
- * @param cnt 뽑을 아이템 개수
- * @returns 랜덤으로 추출된 아이템 리스트
- */
-const getItemRandomly = (array: Wine[], cnt: number): Wine[] => {
-  const copyArr = [...array]; // splice로 인해 원본 배열이 바뀌는 것을 방지하기 위해 복사본 생성
-  if (copyArr.length < cnt) return copyArr;
-  const result: Wine[] = [];
-  while (result.length < cnt) {
-    const randomIndex = Math.floor(Math.random() * copyArr.length);
-    const item = copyArr.splice(randomIndex, 1)[0];
-    if (item !== undefined && !!item) {
-      result.push(item);
-    }
+async function getRecommendedWineList() {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_SERVER_URL}/wines/recommended?limit=8`,
+      {
+        next: {
+          revalidate: 259200, // 3일
+          tags: ['recommended-wines'],
+        },
+      },
+    );
+    const data = await response.json();
+    const ids = data.map((wine) => {
+      return wine.id;
+    });
+
+    useRecommendedWineStore.getState().setWineIds(ids); // zustand 전역 상태로 저장
+    /*
+     * [zustand에서 가져오기]
+     * const storedIds = useRecommendedWineStore.getState().ids;
+     * 리뷰 등록시 위와 같은 방법으로 추천 와인 id들을 받아와, 현재 리뷰가 등록된 와인이 추천 중인 와인이라면 캐시를 무효화합니다.
+     */
+
+    return data;
+  } catch (error: unknown) {
+    console.error('추천 와인 데이터 불러오기 실패:', error);
+
+    const status = (error as ApiErrorResponse)?.response?.status;
+
+    const userMessageMap = {
+      404: '해당 유저를 찾을 수 없습니다.',
+      401: '로그인이 필요합니다.',
+      500: '서버 오류가 발생했습니다.',
+    };
+    throw new ApiErrorClass(status, userMessageMap, '기본 메시지');
   }
-  return result;
-};
-
-/**
- * getCachedRandomWines
- * @description
- * 이번 달 추천 와인에 사용될 데이터를 캐시합니다. (캐시 기간 : 3일)
- * 전체 와인 데이터를 받아와서, 특정 rating 이상의 와인을 최대 8개까지 랜덤으로 선별하여 추천 와인을 반환합니다.
- */
-const getMonthlyRecommendedWines = unstable_cache(
-  async () => {
-    const totalCountResponse = await fetch(
-      `${process.env.NEXT_PUBLIC_API_SERVER_URL}/wines?limit=1`,
-    );
-    const totalCountData = await totalCountResponse.json();
-    const allWinesResponse = await fetch(
-      `${process.env.NEXT_PUBLIC_API_SERVER_URL}/wines?limit=${totalCountData.totalCount}`,
-    );
-    const allWinesData = await allWinesResponse.json();
-
-    const topRatedWines = allWinesData.list.filter(
-      (wine) => wine.avgRating >= 3.5,
-    );
-    return getItemRandomly(topRatedWines, Math.min(8, topRatedWines.length));
-  },
-  ['recommended-wines-random-8'],
-  {
-    revalidate: 259200, // 캐시 3일
-    tags: ['recommended-wines'],
-  },
-);
+}
 
 async function RecommendedWineList() {
-  const monthlyRecommendedWines = await getMonthlyRecommendedWines();
+  const monthlyRecommendedWines = await getRecommendedWineList();
 
   return (
     <div className='rounded-3xl bg-gray-100 p-8'>
-      <h2 className='sub-title-text mb-4'>이번 달 추천 와인</h2>
+      <h2 className='sub-title-text mb-6'>이런 와인은 어떠세요?</h2>
 
       <div className='outer-wrapper relative flex overflow-hidden'>
         {/* 왼쪽 그라데이션 */}

--- a/src/stores/recommendedWines.ts
+++ b/src/stores/recommendedWines.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface RecommendedWineStore {
+  ids: number[];
+  setWineIds: (ids: number[]) => void;
+}
+
+export const useRecommendedWineStore = create<RecommendedWineStore>()(
+  (set) => ({
+    ids: [],
+    setWineIds: (ids) => set({ ids }),
+  }),
+);


### PR DESCRIPTION
### 📌 관련 이슈

- #147

### 📋 작업 내용

백엔드의 `/wines/recommended` 엔드포인트가 정상 작동하는 것으로 확인 되어, api를 다시 연결했습니다.

---

**기존 설계**
```
전제 
- `/wines/recommended` 요청을 보낼 때마다 새로운 추천 와인 목록을 반환한다. (`limit` 설정 가능)
- `/wines/{id}`가 로그인 없이 와인 목록을 받아올 수 있다.
- 평점 4.2점 이상인 와인을 추천한다.
```

1. `/wines/recommended`로 추천 와인 목록을 받아옵니다. 
  - 리뷰가 업데이트 되면서 추천 기준에 탈락되는 상황을 대비하고자, 예비용 와인을 3개 더 추천 받습니다.
  - 받아온 데이터는 캐시를 30일로 설정합니다. (tag: `recommended-wines`)
  - 전역 상태로 추천 와인의 id만 관리합니다.
  - 개별 와인 정보를 요청합니다. 

2. `/wines/{id}`로 개별 와인에 대한 정보를 받아옵니다.
  - 와인 1개에 해당하는 데이터는 캐시를 1시간으로 설정합니다. (tag: `recommended-wine-{id}`)

3. 리뷰가 등록/수정되었을 때, 추천 와인에 해당하는지 검사합니다.
  - 전역 상태 관리중인 와인 id 배열을 통해 검사합니다.
  - 만약 추천 와인이라면, 개별 와인 캐시를 무효화 합니다.

4. 평점 업데이트로 추천 기준에서 탈락한다면?
  - 예비용 와인 id를 받아와서, 다시 2번 과정을 진행합니다.
  - 만약 예비용 와인도 추천 기준에 충족되지 않으면 그 다음 예비용 와인 id로 요청하는 과정을 반복합니다. (만약 남은 예비 와인이 없다면, 모자른 채로 추천합니다.)
  - 추천할 수 있는 예비용 와인이 생겼다면, 전역 상태로 관리중인 추천 와인 id를 업데이트 합니다. (탈락한 와인 id 제거, 신규 와인 id 추가)

여기까지 이런 흐름으로 진행된다면, 평점이 업데이트 될 때마다 캐시가 갱신되면서 추천 와인들의 개별 캐시 타이밍이 모두 달라집니다.
하지만 1번 과정에서 30일 단위로 다시 와인 추천을 받기 때문에, 전체적인 캐시 타이밍도 함께 초기화 될거라고 예상했습니다.

---

그러나... 문제가 생겼습니다.

이 방식은 제공된 api에서는 로그인 없이는 개별 와인 api를 요청할 수 없었고, 로그인이 필요 없는 와인 목록 페이지 특성상 한계가 있었습니다.
따라서 부득이하게 `이 달의 추천 와인` 영역이었지만, `추천 와인`으로 변경되었습니다.
이렇게까지 설계를 했었는데 구현을 못해서 아쉽습니다 ㅠㅠ

---

그래서 다시 생각한 `추천 와인` 캐시 적용 방식은 아래와 같습니다.

1. 캐시를 3일로 하여 `/wines/recommended` 요청
2. 추천 와인의 id만 추출해 전역 상태로 관리
3. 리뷰를 등록할 때, 추천 중인 와인이고 + 평점에 변동이 생겼다면 캐시 무효화 
    → 리뷰 등록/수정 로직이 연결되면 추가할 예정

이때 전역 상태(zustand)를 사용하기 위해서는 클라이언트 사이드에서 가능하고, 
캐시를 무효화 하기 위해서는 서버 사이드에서 가능합니다.
따라서 3번의 과정을 수행하기 위해서 `/wines/revalidate-recommended-wines`의 post api를 구현했습니다.


### 📷 결과 및 스크린샷

![추천와인다시연결](https://github.com/user-attachments/assets/b3f6a56f-a30b-480b-9681-85cd15a3b254)

### 🔎 참고 (선택)
