### PR TITLE
6/18 멘토링 QA 반영

### DIFF
--- a/src/app/wines/components/WineSearchSection.tsx
+++ b/src/app/wines/components/WineSearchSection.tsx
@@ -50,7 +50,7 @@ export default function WineSearchSection() {
     const params = {
       limit: 10,
       cursor: pageParam || 0,
-      name: filters.searchQuery || null,
+      name: filters.searchQuery?.trim() || null,
       rating: filters.selectedRating || null,
       type: filters.selectedWineType || null,
       minPrice: filters.selectedMinPrice || null,

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -4,7 +4,6 @@ import { motion } from 'framer-motion';
 import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
-import useDeviceSize from '@/hooks/useDeviceSize';
 import { cn } from '@/libs/cn';
 
 import { useModalContext } from './ModalContext';
@@ -28,8 +27,6 @@ export default function ModalContent({
 }: ModalBaseProps & { variant?: ModalVariant }) {
   const { isOpen, close } = useModalContext();
   const mountedRef = useRef(false);
-  const { isMobile } = useDeviceSize();
-  const shouldAnimate = variant === 'default' && isMobile;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -57,28 +54,6 @@ export default function ModalContent({
     exit: { y: '100%' },
   };
 
-  // 모바일 default 모달 (애니메이션)
-  const animatedContent = (
-    <motion.div
-      animate='visible'
-      className={contentClassNames}
-      exit='exit'
-      initial='hidden'
-      transition={{ duration: 0.8, ease: [0, 0.71, 0.2, 1.01] }}
-      variants={mobileVariants}
-      onClick={(e) => e.stopPropagation()}
-    >
-      {children}
-    </motion.div>
-  );
-
-  // animatedContent 외의 모든 모달
-  const staticContent = (
-    <div className={contentClassNames} onClick={(e) => e.stopPropagation()}>
-      {children}
-    </div>
-  );
-
   return isOpen
     ? createPortal(
         <motion.div
@@ -89,7 +64,17 @@ export default function ModalContent({
           transition={{ duration: 0.3 }}
           onClick={close}
         >
-          {shouldAnimate ? animatedContent : staticContent}
+          <motion.div
+            animate='visible'
+            className={contentClassNames}
+            exit='exit'
+            initial='hidden'
+            transition={{ duration: 0.8, ease: [0, 0.71, 0.2, 1.01] }}
+            variants={mobileVariants}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {children}
+          </motion.div>
         </motion.div>,
         modalRoot,
       )


### PR DESCRIPTION
### 📌 관련 이슈

- #154

### 📋 작업 내용

- 기존에는 모바일에서만 다른 모달창 애니메이션을 추가했었는데, 뷰포트를 감지하는 부분에서 모달창이 리렌더링이 발생하여 state가 초기화되는 문제가 있었습니다. 따라서 모든 디바이스에서 모달 애니메이션을 아래~위로 등장하도록 통일했습니다.
- 검색어에 `trim()`을 적용하여, 양끝 여백을 제거했습니다.

### 📷 결과 및 스크린샷

|모달 애니메이션 통일|결과|
|-------------------|----|
|![모달애니메이션 통일2](https://github.com/user-attachments/assets/91174bda-c8cf-45ee-9b5c-dc06846b81db)|![모달애니메이션 통일](https://github.com/user-attachments/assets/c01307ec-5d96-46a6-86c9-2b34817a09fd)|

|검색어 공백 제거|
|---------------|
|![검색어공백제거](https://github.com/user-attachments/assets/0ba611fc-a053-48bc-b959-f17a59e9a6cd)|


### 🔎 참고 (선택)
