### PR TITLE
Feat/143 6.18 멘토링 피드백 사항 수정

### DIFF
--- a/src/apis/privateServerInstance.ts
+++ b/src/apis/privateServerInstance.ts
@@ -54,19 +54,12 @@ export const createPrivateServerInstance = async (): Promise<AxiosInstance> => {
   const accessToken = cookieStore.get('accessToken')?.value;
   const refreshToken = cookieStore.get('refreshToken')?.value;
 
-  const cookieHeader = [
-    accessToken ? `accessToken=${accessToken}` : null,
-    refreshToken ? `refreshToken=${refreshToken}` : null,
-  ]
-    .filter(Boolean)
-    .join('; ');
-
   const instance = axios.create({
     baseURL: `${process.env.NEXT_PUBLIC_API_SERVER_URL}`,
     timeout: API_TIMEOUT,
     headers: {
       ...API_HEADERS.JSON,
-      ...(cookieHeader && { Cookie: cookieHeader }),
+      ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
     },
   });
 
@@ -87,15 +80,11 @@ export const createPrivateServerInstance = async (): Promise<AxiosInstance> => {
         console.log('새 accessToken:', newAccessToken);
 
         if (newAccessToken) {
-          const cookieHeader = [
-            `accessToken=${newAccessToken}`,
-            refreshToken ? `refreshToken=${refreshToken}` : null,
-          ]
-            .filter(Boolean)
-            .join('; ');
-
-          originalRequest.headers.Cookie = cookieHeader;
-          console.log('재요청 Cookie 헤더:', originalRequest.headers.Cookie);
+          originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+          console.log(
+            '재요청 Authorization 헤더:',
+            originalRequest.headers.Authorization,
+          );
 
           return instance(originalRequest);
         }

--- a/src/apis/privateServerInstance.ts
+++ b/src/apis/privateServerInstance.ts
@@ -81,10 +81,6 @@ export const createPrivateServerInstance = async (): Promise<AxiosInstance> => {
 
         if (newAccessToken) {
           originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-          console.log(
-            '재요청 Authorization 헤더:',
-            originalRequest.headers.Authorization,
-          );
 
           return instance(originalRequest);
         }

--- a/src/apis/privateServerInstance.ts
+++ b/src/apis/privateServerInstance.ts
@@ -62,7 +62,7 @@ export const createPrivateServerInstance = async (): Promise<AxiosInstance> => {
     .join('; ');
 
   const instance = axios.create({
-    baseURL: `${process.env.NEXT_PUBLIC_SITE_URL}/api`,
+    baseURL: `${process.env.NEXT_PUBLIC_API_SERVER_URL}`,
     timeout: API_TIMEOUT,
     headers: {
       ...API_HEADERS.JSON,

--- a/src/app/myprofile/(tab)/reviews/page.tsx
+++ b/src/app/myprofile/(tab)/reviews/page.tsx
@@ -1,3 +1,4 @@
+import { cookies } from 'next/headers';
 import Link from 'next/link';
 
 import { createPrivateServerInstance } from '@/apis/privateServerInstance';
@@ -24,11 +25,16 @@ interface Review {
 }
 
 export default async function Reviews() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
   const axios = await createPrivateServerInstance();
 
   const { data } = await axios.get('/users/me/reviews', {
     params: {
       limit: 10,
+    },
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
     },
   });
 

--- a/src/app/myprofile/(tab)/reviews/page.tsx
+++ b/src/app/myprofile/(tab)/reviews/page.tsx
@@ -1,4 +1,3 @@
-import { cookies } from 'next/headers';
 import Link from 'next/link';
 
 import { createPrivateServerInstance } from '@/apis/privateServerInstance';
@@ -25,16 +24,11 @@ interface Review {
 }
 
 export default async function Reviews() {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
   const axios = await createPrivateServerInstance();
 
   const { data } = await axios.get('/users/me/reviews', {
     params: {
       limit: 10,
-    },
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
     },
   });
 

--- a/src/app/myprofile/action/user-action.ts
+++ b/src/app/myprofile/action/user-action.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { AxiosError } from 'axios';
+
 import { createPrivateServerInstance } from '@/apis/privateServerInstance';
 
 type UserProfileResult = {
@@ -22,6 +24,14 @@ export async function UserProfile(data: {
     return { success: true };
   } catch (error) {
     console.error('프로필 업데이트 실패:', error);
-    return { success: false, message: '프로필 업데이트 실패' };
+
+    const axiosError = error as AxiosError<{ message?: string }>;
+
+    const serverMessage = axiosError.response?.data?.message;
+
+    return {
+      success: false,
+      message: serverMessage || '프로필 업데이트 실패',
+    };
   }
 }

--- a/src/app/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
+++ b/src/app/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
@@ -19,7 +19,7 @@ import {
 import { UserProfile } from '../../action/user-action';
 import ProfileChangeForm from './ProfileChangeForm';
 
-const DEFAULT_IMAGE_URL =
+export const DEFAULT_IMAGE_URL =
   'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Wine/user/1256/1750160791489/1750160791476.svg';
 
 /**

--- a/src/app/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
+++ b/src/app/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
@@ -87,6 +87,26 @@ export default function ProfileChangeModal({
   }, [user.nickname, user.image]);
 
   /**
+   * 프로필 변경 모달 오픈 핸들러
+   *
+   * - 닉네임, 이미지 상태 초기화
+   * - 선택된 파일 초기화
+   * - 미리보기 URL 해제 및 초기화
+   */
+  const handleOpenModal = () => {
+    // 모달 오픈 시 초기 상태 복원
+    setNickname(user.nickname);
+    setSelectedFile(null);
+    const original = typeof user.image === 'string' ? user.image : '';
+    setImageUrl(original);
+    setDisplayUrl(original || DEFAULT_PROFILE_IMG);
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+      setPreviewUrl(null);
+    }
+  };
+
+  /**
    * 프로필 이미지 변경 핸들러
    * - 선택된 이미지를 API로 요청을 보내 URL을 받아옴
    * @param file 선택된 이미지 파일
@@ -118,7 +138,7 @@ export default function ProfileChangeModal({
   /**
    * 프로필 이미지 삭제 핸들러
    * - 기본 이미지로 변경
-   * - 삭제 버튼 클릭시 DEFAULT_PROFILE_IMG를 API로 보내 매번 새로운 URL을 받아옴
+   * - 삭제 버튼 클릭시 미리 받아온 DEFAULT_PROFILE_IMG URL을 요청으로 보냄
    */
   const handleDeleteImage = () => {
     if (previewUrl) URL.revokeObjectURL(previewUrl);
@@ -229,17 +249,7 @@ export default function ProfileChangeModal({
           className='h-[4.3rem]'
           size='sm'
           variant='outline'
-          onClick={() => {
-            // 모달 오픈 시 초기 상태 복원
-            setNickname(user.nickname);
-            const original = typeof user.image === 'string' ? user.image : '';
-            setImageUrl(original);
-            setDisplayUrl(original || DEFAULT_PROFILE_IMG);
-            if (previewUrl) {
-              URL.revokeObjectURL(previewUrl);
-              setPreviewUrl(null);
-            }
-          }}
+          onClick={handleOpenModal}
         >
           변경하기
         </Button>

--- a/src/app/myprofile/components/ProfileSection.tsx
+++ b/src/app/myprofile/components/ProfileSection.tsx
@@ -1,10 +1,15 @@
+'use client';
+
 import { StaticImageData } from 'next/image';
 
-import { createPrivateServerInstance } from '@/apis/privateServerInstance';
+// import { createPrivateServerInstance } from '@/apis/privateServerInstance';
 import ProfileImg from '@/components/ProfileImg';
 import { cn } from '@/libs/cn';
+import useUserStore from '@/stores/Auth-store/authStore';
 
-import ProfileChangeModal from './ProfileChangeModal/ProfileChangeModal';
+import ProfileChangeModal, {
+  DEFAULT_IMAGE_URL,
+} from './ProfileChangeModal/ProfileChangeModal';
 
 /**
  * 프로필 섹션 컴포넌트
@@ -14,9 +19,13 @@ import ProfileChangeModal from './ProfileChangeModal/ProfileChangeModal';
  * <ProfileSection />
  * ```
  */
-export default async function ProfileSection() {
-  const axios = await createPrivateServerInstance();
-  const { data: user } = await axios.get('/users/me');
+export default function ProfileSection() {
+  // const axios = await createPrivateServerInstance();
+  // const { data: user } = await axios.get('/users/me');
+
+  const user = useUserStore((state) => state.user);
+
+  if (!user) return null;
 
   return (
     <section
@@ -31,7 +40,12 @@ export default async function ProfileSection() {
           {user.nickname}
         </span>
       </div>
-      <ProfileChangeModal user={user} />
+      <ProfileChangeModal
+        user={{
+          image: user.image ?? DEFAULT_IMAGE_URL, // null이면 기본 이미지
+          nickname: user.nickname,
+        }}
+      />
     </section>
   );
 }

--- a/src/components/Modals/WineModal/WineForm.tsx
+++ b/src/components/Modals/WineModal/WineForm.tsx
@@ -64,6 +64,7 @@ export default function WineForm({
   );
 
   const [priceError, setPriceError] = useState('');
+  const [imgError, setImgError] = useState('');
 
   // 이미지 미리보기를 위한 src 설정
   const imageSrc =
@@ -111,34 +112,14 @@ export default function WineForm({
     }
   };
 
-  // const handleUploadFile = async (file: File) => {
-  //   const form = new FormData();
-  //   form.append('file', file);
-
-  //   try {
-  //     const res = await privateInstance.post('/images/upload', form, {
-  //       headers: {
-  //         'Content-Type': 'multipart/form-data',
-  //       },
-  //     });
-
-  //     const { url } = res.data;
-
-  //     setFormData((prev) => ({ ...prev, image: url }));
-  //   } catch (err) {
-  //     console.error('이미지 업로드 실패:', err);
-  //     alert('이미지 업로드에 실패했습니다.');
-  //   }
-  // };
-
   const handleFileChange = (file: File) => {
     if (file.size > MAX_IMAGE_SIZE) {
-      alert('이미지 용량은 5MB 이하만 업로드 가능합니다.');
+      setImgError('이미지 용량은 5MB 이하만 업로드 가능합니다.');
       return;
     }
 
     if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
-      alert('지원하지 않는 파일 형식입니다. (jpg, png, webp만 가능)');
+      setImgError('지원하지 않는 파일 형식입니다. (jpg, png, webp만 가능)');
       return;
     }
 
@@ -229,6 +210,9 @@ export default function WineForm({
             <Image fill alt='사진을 업로드 해주세요' src={FileUpload} />
           )}
         </div>
+        {imgError && (
+          <p className='mt-1 ml-2 text-sm text-red-500'>{imgError}</p>
+        )}
       </InputFile>
     </form>
   );

--- a/src/components/Modals/WineModal/WineForm.tsx
+++ b/src/components/Modals/WineModal/WineForm.tsx
@@ -3,7 +3,6 @@
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
-import { privateInstance } from '@/apis/privateInstance';
 import TriangleArrowIcon from '@/app/assets/icons/triangle-arrow';
 import FileUpload from '@/app/assets/svgs/wine-modal-file-upload.svg';
 import InputFile from '@/components/Inputs/InputFile';
@@ -27,8 +26,10 @@ const OPTION_LABELS = {
   WHITE: '화이트와인',
   SPARKLING: '스파클링와인',
 } as const;
+
 const INPUT_CLASSNAME =
   'w-full border border-gray-300 rounded-[1.6rem], focus:border-2 focus:border-gray-500';
+
 const DEFAULT_DATA: WineFormData = {
   name: '',
   region: '',
@@ -36,6 +37,9 @@ const DEFAULT_DATA: WineFormData = {
   price: 0,
   type: 'RED',
 };
+
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 /**
  * WineForm 컴포넌트
@@ -106,24 +110,39 @@ export default function WineForm({
     }
   };
 
-  const handleUploadFile = async (file: File) => {
-    const form = new FormData();
-    form.append('file', file);
+  // const handleUploadFile = async (file: File) => {
+  //   const form = new FormData();
+  //   form.append('file', file);
 
-    try {
-      const res = await privateInstance.post('/images/upload', form, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-      });
+  //   try {
+  //     const res = await privateInstance.post('/images/upload', form, {
+  //       headers: {
+  //         'Content-Type': 'multipart/form-data',
+  //       },
+  //     });
 
-      const { url } = res.data;
+  //     const { url } = res.data;
 
-      setFormData((prev) => ({ ...prev, image: url }));
-    } catch (err) {
-      console.error('이미지 업로드 실패:', err);
-      alert('이미지 업로드에 실패했습니다.');
+  //     setFormData((prev) => ({ ...prev, image: url }));
+  //   } catch (err) {
+  //     console.error('이미지 업로드 실패:', err);
+  //     alert('이미지 업로드에 실패했습니다.');
+  //   }
+  // };
+
+  const handleFileChange = (file: File) => {
+    if (file.size > MAX_IMAGE_SIZE) {
+      alert('이미지 용량은 5MB 이하만 업로드 가능합니다.');
+      return;
     }
+
+    if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+      alert('지원하지 않는 파일 형식입니다. (jpg, png, webp만 가능)');
+      return;
+    }
+
+    setFormData((prev) => ({ ...prev, image: file }));
+    console.log(file);
   };
 
   return (
@@ -193,7 +212,7 @@ export default function WineForm({
           </SelectBox.Options>
         </SelectBox>
       </div>
-      <InputFile label='와인 사진' onChange={handleUploadFile}>
+      <InputFile label='와인 사진' onChange={handleFileChange}>
         <div className='relative h-[14rem] w-[14rem]'>
           {formData.image !== '' ? (
             <Image

--- a/src/components/Modals/WineModal/WineForm.tsx
+++ b/src/components/Modals/WineModal/WineForm.tsx
@@ -6,6 +6,10 @@ import { useEffect, useState } from 'react';
 import TriangleArrowIcon from '@/app/assets/icons/triangle-arrow';
 import FileUpload from '@/app/assets/svgs/wine-modal-file-upload.svg';
 import InputFile from '@/components/Inputs/InputFile';
+import {
+  ALLOWED_IMAGE_TYPES,
+  MAX_IMAGE_SIZE,
+} from '@/constants/fileValidation';
 import { cn } from '@/libs/cn';
 
 import InputPair from '../../Inputs/InputPair';
@@ -37,9 +41,6 @@ const DEFAULT_DATA: WineFormData = {
   price: 0,
   type: 'RED',
 };
-
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 
 /**
  * WineForm 컴포넌트

--- a/src/components/Modals/WineModal/WineModal.tsx
+++ b/src/components/Modals/WineModal/WineModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
@@ -45,6 +46,7 @@ export default function WineModal({
   wineData?: WineFormData;
 }) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const user = useUserStore((state) => state.user);
 
   // 폼 입력 상태: 초기값은 수정 모드면 wineData, 등록 모드면 빈 값
@@ -96,7 +98,7 @@ export default function WineModal({
       };
 
       await WineData(payload);
-
+      await queryClient.invalidateQueries({ queryKey: ['wines'] }); // 와인 목록 페이지에서 와인이 등록되었을 때 바로 반영되도록 하기 위해
       alert(
         wineData
           ? '와인이 성공적으로 수정되었습니다.'

--- a/src/components/Modals/WineModal/WineModal.tsx
+++ b/src/components/Modals/WineModal/WineModal.tsx
@@ -153,32 +153,27 @@ export default function WineModal({
         </ModalBody>
         <ModalFooter>
           <ModalClose />
-          <div className='flex w-full justify-between'>
-            <div className='w-[3rem]'>
-              <ModalClose asChild>
-                <Button
-                  className='w-[10.8rem] md:w-[9rem] xl:w-[10rem]'
-                  disabled={isLoading}
-                  variant='secondary'
-                  onClick={() => setIsOpen(false)}
-                >
-                  취소
-                </Button>
-              </ModalClose>
-            </div>
-            <div>
-              <Button
-                className='w-[27rem] md:w-[24rem] xl:w-[35rem]'
-                loading={isLoading}
-                variant='primary'
-                onClick={() => {
-                  handleSubmit();
-                }}
-              >
-                {isLoading ? '처리 중...' : wineData ? '수정하기' : '등록하기'}
-              </Button>
-            </div>
-          </div>
+          <ModalClose asChild>
+            <Button
+              className='w-[10.8rem] flex-1 md:w-[9rem] xl:w-[10rem]'
+              disabled={isLoading}
+              variant='secondary'
+              onClick={() => setIsOpen(false)}
+            >
+              취소
+            </Button>
+          </ModalClose>
+
+          <Button
+            className='w-[27rem] flex-2 md:w-[24rem] xl:w-[35rem]'
+            loading={isLoading}
+            variant='primary'
+            onClick={() => {
+              handleSubmit();
+            }}
+          >
+            {isLoading ? '처리 중...' : wineData ? '수정하기' : '등록하기'}
+          </Button>
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/src/constants/fileValidation.ts
+++ b/src/constants/fileValidation.ts
@@ -1,0 +1,2 @@
+export const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+export const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp'];


### PR DESCRIPTION
### 📌 관련 이슈

- #143 

### 📋 작업 내용

### axios 인스턴스 수정
- `privateSeverInstance`를 기존 `/api`를 통해 받아오는 방식에서 바로 서버로 전송하는 방식으로 변경했습니다.
- 변경 이후 발생한 마이프로필 페이지 401 에러 대응 로직을 추가 적용 했습니다.

### 와인 등록 / 수정 모달
- `privateServerInstance` 수정으로 와인 등록 / 수정이 불가능했던 이슈를 해결했습니다.
- **이미지 업로드 흐름 개선**
  - 등록/수정 버튼 클릭 시 이미지 서버 업로드 후 URL 받아서 →  와인 데이터 전송 순서로 수정했습니다.
  - 이미지 미리보기는 업로드된 파일 객체를 미리보기 URL로 변경하여 보이도록 했습니다.

### 프로필 변경 모달
- **이미지 업로드 흐름 개선**
  - 변경하기 버튼 클릭 시 이미지 서버 업로드 후 URL을 받아서 →  user 정보와 함께 전송되도록 변경했습니다.
  - 이미지 미리보기는 파일 객체 기반 URL로 반영되도록 수정했습니다.

- **useUserStore 연동**
  - ProfileSection이 useUserStore를 사용하도록 구조 변경됨에 따라
  - 프로필 변경 후 `useUserStore.getState().setUser()`를 통해 전역 상태 갱신할 수 있도록 했습니다.
    - Header에서도 변경된 사용자 이미지가 실시간 반영이 되고 있습니다.

- **닉네임 중복 에러메시지** 
  - 닉네임이 중복되었을 경우 서버에서 전송해주는 error 메세지인 "이미 사용중인 닉네임입니다."가 출력되도록 했습니다.

### 📷 결과 및 스크린샷

### 프로필 변경
https://github.com/user-attachments/assets/f161dbb2-1e94-40db-b815-05f32bdf7fc4

### 와인 등록
https://github.com/user-attachments/assets/9d849f5f-5870-442f-a418-ea70eefd7393

### 와인 수정
https://github.com/user-attachments/assets/cdd5ef95-9fe9-4e21-8531-2b90073bcf28


### 🔎 참고 (선택)

이번 이슈를 해결하면서, 각자 작업하셨던 코드들을 공유해주시고,  막힌 부분에 대해서도 적극적으로 도와주셔서 수월하게 해결할 수 있었습니다!
혼자였다면 훨씬 더 오래 걸렸을 문제였는데, 덕분에 빠르게 방향을 잡을 수 있었던 것 같습니다 👍  
너무 감사합니다 ㅠㅠ 🙏🙇‍♀️ 