### PR TITLE
Feat/158 마이프로필 페이지 더보기 이슈

### DIFF
--- a/src/app/myprofile/components/LoadMoreBtn.tsx
+++ b/src/app/myprofile/components/LoadMoreBtn.tsx
@@ -80,22 +80,22 @@ export default function LoadMoreButton({ type, initialCursor }: Props) {
     }
   };
 
-  if (!cursor) return null;
-
   return (
     <>
       <div className='mt-10 flex flex-col gap-10'>{items.map(renderItem)}</div>
-      <div className='mt-8 mb-15 self-center'>
-        <Button
-          loading={loading}
-          round='rounded'
-          size='md'
-          variant='outline'
-          onClick={handleLoadMore}
-        >
-          더 보기
-        </Button>
-      </div>
+      {cursor && (
+        <div className='mt-8 mb-15 self-center'>
+          <Button
+            loading={loading}
+            round='rounded'
+            size='md'
+            variant='outline'
+            onClick={handleLoadMore}
+          >
+            더 보기
+          </Button>
+        </div>
+      )}
     </>
   );
 }


### PR DESCRIPTION
### 📌 관련 이슈

- #158 

### 📋 작업 내용

- 마이프로필 페이지에서 마지막 남은 데이터를 불러오기 위해 더보기를 클릭하면
- 데이터가 초기화 되어 초기 10개의 데이터만 보이는 문제가 발생했습니다.
- (자세한 문제 영상과 해결 후 비교 영상은 하단에 첨부해두었습니다.)

### 문제 원인
- 서버 API가 limit=5로 요청 시 남은 데이터가 3개만 존재하면, nextCursor가 null로 반환됩니다.

- 기존 코드에서는 `if (!cursor) return null`로 전체 컴포넌트를 렌더링하지 않도록 되어 있었습니다.

- 이로 인해, "더 보기" 버튼 클릭 후 nextCursor가 null이 되면 LoadMoreButton 컴포넌트가 통째로 사라지고, 서버 컴포넌트에서 렌더링한 초기 10개만 다시 보이게 되는 문제가 발생했습니다.

### 해결 방법
- nextCursor가 null이더라도 기존 items는 화면에 그대로 남아 있도록 수정했습니다.

- cursor가 null인 경우에는 "더 보기" 버튼만 사라지도록 조건부 렌더링으로 변경하여 문제를 해결했습니다.

- 기존 `if (!cursor) return null` 구문은 제거하였습니다.
### 📷 결과 및 스크린샷

### 문제 영상
https://github.com/user-attachments/assets/670357e6-d87e-4674-8cf9-a21b65bdd2c6


### 문제 해결 후
https://github.com/user-attachments/assets/922d6f78-0ce5-4413-9e42-50ebc4d2a8d8


### 🔎 참고 (선택)
