### PR TITLE
아이폰 사파리에서 모달창의 크기가 제대로 작동하지 않는 오류 해결

### DIFF
--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -44,7 +44,7 @@ export default function ModalContent({
   const baseClass =
     variant === 'confirm'
       ? 'content-text min-w-[30rem] flex h-screen max-h-[80%] w-screen flex-col bg-white p-8 shadow-xl h-fit w-[40rem] max-w-[65rem] rounded-4xl'
-      : 'content-text min-w-[30rem] absolute bottom-0 flex h-fit max-h-[85%] w-screen flex-col rounded-t-4xl bg-white p-8 shadow-xl md:relative md:h-fit md:w-[50%] md:max-w-[60rem] md:rounded-4xl';
+      : 'relative content-text min-w-[30rem] mt-auto flex h-fit max-h-[85%] md:mt-0 w-screen flex-col rounded-t-4xl p-8 shadow-xl md:h-fit md:w-[50%] md:max-w-[60rem] md:rounded-4xl bg-white';
   const contentClassNames = cn(baseClass, className);
 
   // 애니메이션 설정


### PR DESCRIPTION
### 📌 관련 이슈

- #177

### 📋 작업 내용

- 애플 사파리에서는 `absolute`와 `h-fit`이 충돌해 제대로 작동하지 않는다고 합니다..!
- 따라서 `margin-top`을 사용해 모달창의 포지션을 다시 설정했습니다.

### 📷 결과 및 스크린샷


|변경 전|변경 후|
|-----|-------|
|![IMG_6855](https://github.com/user-attachments/assets/41be7d59-b9a4-44ba-9632-dde55e30fe54)|<img width="1500" alt="image" src="https://github.com/user-attachments/assets/de3f4573-b1cc-42a7-97ee-d79b75450f4a" />|


### 🔎 참고 (선택)

pwa를 도입했기 때문에 사파리로도 QA를 한 번 해야 할 것 같습니다....
