### PR TITLE
Refactor/184 와인 상세페이지 와인 수정 시 바로 반영되도록 수정

### DIFF
--- a/src/components/Modals/WineModal/WineModal.tsx
+++ b/src/components/Modals/WineModal/WineModal.tsx
@@ -120,7 +120,17 @@ export default function WineModal({
       };
 
       await WineData(payload);
-      await queryClient.invalidateQueries({ queryKey: ['wines'] }); // 와인 목록 페이지에서 와인이 등록되었을 때 바로 반영되도록 하기 위해
+
+      if (wineData) {
+        await queryClient.invalidateQueries({
+          queryKey: ['wine', String(wineData.id)], // 와인 상세 페이지에서 와인이 수정되었을 때 바로 반영되도록 하기 위해
+        });
+      } else {
+        await queryClient.invalidateQueries({
+          queryKey: ['wines'], // 와인 목록 페이지에서 와인이 등록되었을 때 바로 반영되도록 하기 위해
+        });
+      }
+
       alert(
         wineData
           ? '와인이 성공적으로 수정되었습니다.'


### PR DESCRIPTION
### 📌 관련 이슈

- #184 

### 📋 작업 내용

### 문제 상황
- 와인 상세페이지에서 와인 수정을 했을 때 바로 반영되지 않는 문제가 발생했습니다.

### 원인
- 기존 코드에는 수정 시 상세 페이지 데이터를 invalidateQueries로 갱신하는 처리가 없었습니다.

### 해결 방법
- 수정 시 `['wine', wine.id]` 쿼리를 `invalidate` 하여 상세 페이지가 바로 반영되도록 처리했습니다.

### 📷 결과 및 스크린샷


https://github.com/user-attachments/assets/5f7bfb5b-43ee-4361-982f-4c279a2055f0



### 🔎 참고 (선택)
- 상세 페이지에서는 useParams 를 통해 wineId 를 String 으로 queryKey 에 사용하고 있었지만, WineModal 쪽에서는 wine 데이터에 존재하는 id(Number 타입)로 invalidateQueries 를 호출하고 있던 부분을 놓치고 있어 좀 헤맸었습니다 😅
- 저와 같은 실수를 하지 않길 바라며 남겨둡니다 .. ㅎㅎ