### PR TITLE
와인 목록 페이지 QA 반영

### DIFF
--- a/src/app/(with-header)/wines/components/WineFilterSidebar.tsx
+++ b/src/app/(with-header)/wines/components/WineFilterSidebar.tsx
@@ -100,24 +100,26 @@ function MobileFilterButton({
           </ModalBody>
           <ModalFooter>
             <ModalClose />
-            <Button
-              className='flex-1'
-              size='sm'
-              variant='secondary'
-              onClick={() => {
-                const resetState: FilterState = {
-                  selectedRating: 0,
-                  selectedWineType: '',
-                  selectedMinPrice: 0,
-                  selectedMaxPrice: priceMaxRange ?? DEFAULT_MAX_PRICE,
-                  searchQuery: filterState.searchQuery, // 검색어는 유지
-                };
-                onFilterChange(resetState);
-                setTempFilterState(resetState);
-              }}
-            >
-              초기화
-            </Button>
+            <ModalClose asChild>
+              <Button
+                className='flex-1'
+                size='sm'
+                variant='secondary'
+                onClick={() => {
+                  const resetState: FilterState = {
+                    selectedRating: 0,
+                    selectedWineType: '',
+                    selectedMinPrice: 0,
+                    selectedMaxPrice: priceMaxRange ?? DEFAULT_MAX_PRICE,
+                    searchQuery: filterState.searchQuery, // 검색어는 유지
+                  };
+                  onFilterChange(resetState);
+                  setTempFilterState(resetState);
+                }}
+              >
+                초기화
+              </Button>
+            </ModalClose>
             <ModalClose asChild>
               <Button
                 className='flex-2'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -139,11 +139,11 @@
   }
 
   .rolling-list-original {
-    animation: rollingleft1 25s linear infinite;
+    animation: rollingleft1 40s linear infinite;
   }
 
   .rolling-list-clone {
-    animation: rollingleft2 25s linear infinite;
+    animation: rollingleft2 40s linear infinite;
   }
 
   .outer-wrapper:hover .rolling-list-original,


### PR DESCRIPTION
### 📌 관련 이슈

- #200

### 📋 작업 내용

- 필터링 모달창에서 초기화 버튼을 누르면 창이 닫히면서 초기화가 적용됩니다.
- 추천 와인 롤링 애니메이션의 속도를 늦췄습니다.

### 📷 결과 및 스크린샷

-

### 🔎 참고 (선택)

데스크탑에서 필터링이 수정되면 화면 상단으로 스크롤되는 부분을 수정하려고 했는데,
현재 검색이 되는 트리거가 검색 버튼이 아닌 검색 관련 상태가 변경되었을때 자동으로 api 요청을 보내고 있습니다.
그래서 header에서 바로 와인 페이지로 접속해도 바로 검색창 위까지만 스크롤 되는 이슈가 있어서 우선 빼고 PR을 올렸습니다.
그래도 새로고침을 하거나 스크롤이 안되는건 아니라서, 위 이슈를 감안해도 괜찮으시다면 추가해서 다시 commit 하겠습니다!