### PR TITLE
Refactor/199 4차 QA 피드백 반영

### DIFF
--- a/src/app/(with-header)/myprofile/action/user-action.ts
+++ b/src/app/(with-header)/myprofile/action/user-action.ts
@@ -25,13 +25,35 @@ export async function UserProfile(data: {
   } catch (error) {
     console.error('프로필 업데이트 실패:', error);
 
-    const axiosError = error as AxiosError<{ message?: string }>;
+    const axiosError = error as AxiosError<{
+      message?: string;
+      details?: {
+        'body.nickname'?: {
+          message: string;
+          value: string;
+        };
+      };
+    }>;
 
-    const serverMessage = axiosError.response?.data?.message;
+    // 기본 에러 메세지
+    let serverMessage =
+      axiosError.response?.data?.message || '프로필 업데이트 실패';
+
+    // nickname 관련 validation 실패 처리
+    const nicknameErrorMessage =
+      axiosError.response?.data?.details?.['body.nickname']?.message;
+
+    if (nicknameErrorMessage === 'maxLength 30') {
+      serverMessage = '닉네임은 최대 30글자만 입력이 가능합니다.';
+    }
+
+    if (nicknameErrorMessage === 'unique') {
+      serverMessage = '이미 사용중인 닉네임입니다.';
+    }
 
     return {
       success: false,
-      message: serverMessage || '프로필 업데이트 실패',
+      message: serverMessage,
     };
   }
 }

--- a/src/app/(with-header)/myprofile/components/CardModal.tsx
+++ b/src/app/(with-header)/myprofile/components/CardModal.tsx
@@ -1,71 +1,61 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import CloseIcon from '@/app/assets/icons/close';
 
 /**
- * Myprofile 페이지 CardModal 컴포넌트
+ * Myprofile 페이지 CardModal 컴포넌트 (div 기반)
  *
- * - Myprofile 페이지에서 Card 클릭 시 패럴렐 + 인터셉팅 라우팅을 적용하기 위해 사용됩니다.
- * - dialog 요소를 사용하여 모달을 생성합니다.
- * - 모달이 열리면 body의 스크롤을 비활성화하고, 닫히면 다시 활성화합니다.
- * - 외부 영역 클릭 또는 Close 버튼 클릭 시 뒤로 가기(router.back())를 호출하여 모달을 닫습니다.
- *
- * @param {ReactNode} props.children - 모달 내부에 렌더링될 콘텐츠
+ * - 패럴렐 + 인터셉팅 라우팅에서 사용
+ * - dialog 대신 div + Portal로 구성 (중첩 모달 대응 위해)
+ * - 모달이 열리면 body 스크롤 비활성화
+ * - 외부 클릭 또는 닫기 버튼 클릭 시 router.back() 호출
  */
 export default function Modal({ children }: { children: ReactNode }) {
-  const dialogRef = useRef<HTMLDialogElement>(null);
   const router = useRouter();
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    // 모달이 열려 있지 않다면 showModal()을 호출
-    if (!dialogRef.current?.open) {
-      dialogRef.current?.showModal();
-      dialogRef.current?.scrollTo({
-        top: 0,
-      });
+    setMounted(true);
+    document.body.style.overflow = 'hidden';
+    document.documentElement.style.overflow = 'hidden';
 
-      // 모달이 열리면 배경 페이지 스크롤을 비활성화
-      document.body.style.overflow = 'hidden';
-      document.documentElement.style.overflow = 'hidden';
-    }
+    return () => {
+      document.body.style.overflow = '';
+      document.documentElement.style.overflow = '';
+    };
   }, []);
 
-  /**
-   * 모달 닫기 핸들러
-   * - router.back()을 호출하여 이전 페이지로 이동
-   */
   const handleClose = () => {
-    document.body.style.overflow = '';
-    document.documentElement.style.overflow = '';
     router.back();
   };
 
+  if (!mounted) return null;
+
   return createPortal(
-    <dialog
-      ref={dialogRef}
-      className='scrollbar-none fixed top-1/2 left-1/2 z-50 h-full w-[90vw] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-2xl border-0 p-10 shadow-xl backdrop:bg-[rgba(0,0,0,0.7)] md:w-[80vw] md:p-20'
-      onClick={(e) => {
-        if ((e.target as HTMLElement).nodeName === 'DIALOG') {
-          handleClose();
-        }
-      }}
-      onClose={() => router.back()}
+    <div
+      className='fixed inset-0 z-[60] flex items-center justify-center bg-[rgba(0,0,0,0.7)]'
+      onClick={handleClose}
     >
-      {/* 모달 닫기 버튼 */}
-      <button
-        className='absolute top-6 right-6 cursor-pointer'
-        type='button'
-        onClick={handleClose}
+      <div
+        className='relative max-h-[90vh] w-[90vw] overflow-y-auto rounded-2xl bg-white p-10 shadow-xl md:w-[80vw] md:p-20'
+        onClick={(e) => e.stopPropagation()}
       >
-        <CloseIcon className='h-[1.5rem] w-[1.5rem] text-gray-400 hover:text-gray-600 md:h-[2rem] md:w-[2rem]' />
-      </button>
-      {/* 모달 콘텐츠 */}
-      {children}
-    </dialog>,
+        {/* 모달 닫기 버튼 */}
+        <button
+          className='absolute top-6 right-6 cursor-pointer'
+          type='button'
+          onClick={handleClose}
+        >
+          <CloseIcon className='h-[1.5rem] w-[1.5rem] text-gray-400 hover:text-gray-600 md:h-[2rem] md:w-[2rem]' />
+        </button>
+
+        {children}
+      </div>
+    </div>,
     document.getElementById('modal-root') as HTMLElement,
   );
 }

--- a/src/app/(with-header)/myprofile/components/CardModal.tsx
+++ b/src/app/(with-header)/myprofile/components/CardModal.tsx
@@ -41,7 +41,7 @@ export default function Modal({ children }: { children: ReactNode }) {
       onClick={handleClose}
     >
       <div
-        className='relative max-h-[90vh] w-[90vw] overflow-y-auto rounded-2xl bg-white p-10 shadow-xl md:w-[80vw] md:p-20'
+        className='scrollbar-none relative max-h-[90vh] w-[90vw] overflow-y-auto rounded-2xl bg-white p-10 shadow-xl md:w-[80vw] md:p-20'
         onClick={(e) => e.stopPropagation()}
       >
         {/* 모달 닫기 버튼 */}

--- a/src/app/(with-header)/myprofile/components/ProfileChangeModal/ProfileChangeForm.tsx
+++ b/src/app/(with-header)/myprofile/components/ProfileChangeModal/ProfileChangeForm.tsx
@@ -39,9 +39,9 @@ export default function ProfileChangeForm({
             src={imageSrc || undefined}
           />
         </InputFile>
-        <span className='text-[1.2rem] text-gray-500'>
-          {imgState === 'preview' ? '미리보기 이미지' : '프로필 사진 변경'}
-        </span>
+        {imgState === 'preview' && (
+          <span className='text-[1.2rem] text-gray-500'>미리보기 이미지</span>
+        )}
         <div className='flex gap-[0.3rem]'>
           {isDeletable && (
             <Button

--- a/src/app/(with-header)/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
+++ b/src/app/(with-header)/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
@@ -233,7 +233,7 @@ export default function ProfileChangeModal({
         if (result.message === '이미 사용중인 닉네임입니다.') {
           toast.warning(result.message);
         } else {
-          toast.warning('프로필 변경에 실패했습니다.');
+          toast.error('프로필 변경에 실패했습니다.');
         }
       }
     } catch (err) {

--- a/src/app/(with-header)/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
+++ b/src/app/(with-header)/myprofile/components/ProfileChangeModal/ProfileChangeModal.tsx
@@ -230,11 +230,7 @@ export default function ProfileChangeModal({
 
         router.refresh();
       } else {
-        if (result.message === '이미 사용중인 닉네임입니다.') {
-          toast.warning(result.message);
-        } else {
-          toast.error('프로필 변경에 실패했습니다.');
-        }
+        toast.error(result.message);
       }
     } catch (err) {
       console.error(err);

--- a/src/app/(with-header)/myprofile/components/ProfileSection.tsx
+++ b/src/app/(with-header)/myprofile/components/ProfileSection.tsx
@@ -2,7 +2,6 @@
 
 import { StaticImageData } from 'next/image';
 
-// import { createPrivateServerInstance } from '@/apis/privateServerInstance';
 import ProfileImg from '@/components/ProfileImg';
 import { cn } from '@/libs/cn';
 import useUserStore from '@/stores/Auth-store/authStore';
@@ -20,9 +19,6 @@ import ProfileChangeModal, {
  * ```
  */
 export default function ProfileSection() {
-  // const axios = await createPrivateServerInstance();
-  // const { data: user } = await axios.get('/users/me');
-
   const user = useUserStore((state) => state.user);
 
   if (!user) return null;
@@ -36,7 +32,7 @@ export default function ProfileSection() {
     >
       <div className={cn('flex items-center gap-[1.6rem]', 'xl:flex-col')}>
         <ProfileImg size='lg' src={user.image as string | StaticImageData} />
-        <span className='text-xl font-bold text-gray-800 md:text-2xl'>
+        <span className='px-8 text-xl font-bold text-gray-800 md:text-2xl'>
           {user.nickname}
         </span>
       </div>

--- a/src/app/(with-header)/wines/[wineId]/components/ReviewCard.tsx
+++ b/src/app/(with-header)/wines/[wineId]/components/ReviewCard.tsx
@@ -94,7 +94,6 @@ export default function ReviewCard({
 
   const handleLike = async (e) => {
     e.preventDefault();
-    e.stopPropagation();
     setIsLiked(!isLiked);
   };
 
@@ -124,7 +123,6 @@ export default function ReviewCard({
 
   const handleToggle = (e) => {
     e.preventDefault();
-    e.stopPropagation();
     setIsOpen((prev) => !prev);
   };
 

--- a/src/app/(with-header)/wines/[wineId]/components/ReviewCard.tsx
+++ b/src/app/(with-header)/wines/[wineId]/components/ReviewCard.tsx
@@ -92,7 +92,9 @@ export default function ReviewCard({
     onEdit?.(review);
   };
 
-  const handleLike = async () => {
+  const handleLike = async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
     setIsLiked(!isLiked);
   };
 
@@ -120,7 +122,9 @@ export default function ReviewCard({
     }
   }, [userInfo?.id, user?.id]);
 
-  const handleToggle = () => {
+  const handleToggle = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
     setIsOpen((prev) => !prev);
   };
 

--- a/src/components/Modal/ModalContent.tsx
+++ b/src/components/Modal/ModalContent.tsx
@@ -38,7 +38,7 @@ export default function ModalContent({
 
   // 모달 뒷배경 스타일
   const overlayClass =
-    'fixed inset-0 z-50 flex items-center justify-center bg-black/50';
+    'fixed inset-0 z-100 flex items-center justify-center bg-black/50';
 
   // 모달창 스타일
   const baseClass =

--- a/src/components/Modals/WineModal/WineForm.tsx
+++ b/src/components/Modals/WineModal/WineForm.tsx
@@ -175,7 +175,9 @@ export default function WineForm({
           }
           {...(isEdit && { value: wineData.type })}
         >
-          <SelectBox.Trigger triggerClassName='w-full focus:border-2 focus:border-gray-500'>
+          <SelectBox.Trigger
+            triggerClassName={`w-full focus:border-2 text-md focus:border-gray-500 ${isEdit ? '' : 'text-gray-800'}`}
+          >
             <>
               {OPTION_LABELS[formData.type] || ''}
               <TriangleArrowIcon />

--- a/src/components/Modals/WineModal/WineModal.tsx
+++ b/src/components/Modals/WineModal/WineModal.tsx
@@ -132,7 +132,7 @@ export default function WineModal({
         });
       }
 
-      alert(
+      toast.success(
         wineData
           ? '와인이 성공적으로 수정되었습니다.'
           : '와인이 성공적으로 등록되었습니다.',


### PR DESCRIPTION
### 📌 관련 이슈

- #199 

### 📋 작업 내용

- 와인 등록 모달에서 기본값 "RED"가 설정됨에 따라, 등록 시 해당 값이 선택되었음을 명확히 보여주기 위해 색상을 진하게 변경했습니다.  
  (기본값이 "RED"로 설정되지 않으면 SelectBox에 아무 값도 표시되지 않아 해당 방식으로 대체했습니다.)

- SelectBox에 표시되는 텍스트 크기를 placeholder와 동일하게 맞췄습니다.

- 와인 등록/수정 시 알림을 `alert`에서 `toast` 방식으로 변경했습니다.

- ProfileSection에서 닉네임이 길어질 경우 레이아웃이 깨지는 문제를 방지하기 위해 padding을 추가했습니다.

- 마이프로필 페이지의 ReviewCard에 `max-h-[40rem]` 및 `overflow-y-scroll`을 적용하여,  
  리뷰 내용이 길어질 경우 스크롤로 확인할 수 있도록 수정했습니다.

- 와인 상세페이지에서 사용되는 ReviewCard에 `e.preventDefault()`를 추가하여,  
  마이프로필 페이지에서 toggle/heart 아이콘을 클릭해도 `Link`의 기본 동작이 수행되지 않도록 했습니다.

- 프로필 변경 모달에서 이미지가 변경되었을 때만 "미리보기 이미지"가 표시되도록 하여 기존 "프로필 이미지 변경"은 렌더링 되지 않도록 했습니다.

- 닉네임이 30자를 초과할 경우 백엔드에서 오류를 보내는 것을 확인하여,  
  프론트엔드에서 30자 초과 시 에러 메시지를 표시하도록 유효성 검사를 추가했습니다.

### 인터셉팅 + 패럴렐 라우팅 환경에서 모달이 보이지 않던 이슈 수정

####  문제 원인  
기존 인터셉팅 라우팅용 모달이 `<dialog>` 요소 기반으로 구현되어 있어,  
브라우저의 top-layer stack에 의해 `z-index`가 높더라도  
내부 공통 모달이 상위 모달 위에 렌더링되지 않는 문제가 있었습니다.

#### 해결 방법  
`<dialog>`를 제거하고, `div + Portal` 기반으로 모달 구조를 리팩토링하여  
중첩 모달이 상위 모달 위에 정상적으로 렌더링되도록 수정했습니다.  
이를 통해 z-index 제어가 가능해져 인터셉팅 라우팅 환경에서도 중첩 모달이 잘 동작합니다.

### 📷 결과 및 스크린샷

| 변경 항목                            | 이미지 URL |
|-------------------------------------|------------|
| 패럴렐 + 인터셉팅 모달 띄우기        | ![패럴렐 모달](https://github.com/user-attachments/assets/e298ed6e-055a-4ace-a669-99248933239d) |
| 닉네임 패딩 추가                     | ![닉네임 패딩](https://github.com/user-attachments/assets/a4752455-7693-4ff8-a309-ecc06e822ac4) |
| 와인 등록 SelectBox 크기 및 색상 조정 | ![와인 등록](https://github.com/user-attachments/assets/9734d27a-bfb3-4d57-a302-876406600f36) |

### 닉네임 30자 제한
https://github.com/user-attachments/assets/f42ee57a-f02c-4127-bc47-6d5409f959e1

### 🔎 참고 (선택)
- 작업하다 보니 하나의 브랜치에서 변경 사항이 조금 많아졌습니다 😅
- 천천히 확인해보시고 혹시 놓친 피드백 사항이 있다면 말씀해주세요!
