### PR TITLE
Refactor/209 목록 페이지 와인 크기 수정

### DIFF
--- a/src/app/(with-header)/myprofile/components/LoadMoreBtn.tsx
+++ b/src/app/(with-header)/myprofile/components/LoadMoreBtn.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { privateInstance } from '@/apis/privateInstance';
 import Button from '@/components/Button';
@@ -51,6 +51,11 @@ export default function LoadMoreButton({ type, initialCursor }: Props) {
   const [items, setItems] = useState<Wine[] | Review[]>([]);
   const [cursor, setCursor] = useState(initialCursor);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setItems([]);
+    setCursor(initialCursor);
+  }, [initialCursor]);
 
   const handleLoadMore = async () => {
     if (!cursor) return;

--- a/src/app/(with-header)/wines/components/WineListCard.tsx
+++ b/src/app/(with-header)/wines/components/WineListCard.tsx
@@ -71,7 +71,7 @@ export default function WineListCard({
           wineCountry={country}
           wineCountryClassName='max-sm:text-[1.2rem] line-clamp-1 max-sm:mb-3'
           wineImage={image}
-          wineImageClassName='h-[22rem] w-[10rem] sm:w-[12rem]'
+          wineImageClassName='mr-8'
           wineName={name}
           wineNameClassName='text-[2rem] mb-2 sm:text-[2.7rem] md:text-[3rem] font-medium line-clamp-2 sm:line-clamp-2'
         />

--- a/src/components/Modals/WineModal/WineForm.tsx
+++ b/src/components/Modals/WineModal/WineForm.tsx
@@ -24,6 +24,24 @@ export type WineFormData = {
   type: string;
 };
 
+const WINE_NAME_PLACEHOLDERS = [
+  'Château Margaux',
+  'Louis Latour Pinot Noir',
+  'Tenuta San Guido Sassicaia',
+  'Opus One',
+  'Pfeiffer Going for Broke',
+];
+
+const REGION_PLACEHOLDERS = [
+  'Bordeaux, France',
+  'Tuscany, Italy',
+  'Sonoma County, California, USA',
+  'Barossa Valley, Australia',
+  'Mendoza, Argentina',
+];
+
+const PRICE_PLACEHOLDERS = ['49,000', '64,900', '120,000', '89,500', '230,000'];
+
 const OPTIONS = ['RED', 'WHITE', 'SPARKLING'];
 const OPTION_LABELS = {
   RED: '레드와인',
@@ -39,7 +57,7 @@ const DEFAULT_DATA: WineFormData = {
   region: '',
   image: '',
   price: 0,
-  type: 'RED',
+  type: OPTIONS[Math.floor(Math.random() * OPTIONS.length)],
 };
 
 /**
@@ -58,6 +76,14 @@ export default function WineForm({
   wineData?: WineFormData;
   onChange?: (data: WineFormData) => void;
 }) {
+  const DEFAULT_DATA: WineFormData = {
+    name: '',
+    region: '',
+    image: '',
+    price: 0,
+    type: OPTIONS[Math.floor(Math.random() * OPTIONS.length)],
+  };
+
   const isEdit = !!wineData;
   const [formData, setFormData] = useState<WineFormData>(
     wineData ?? DEFAULT_DATA,
@@ -65,6 +91,19 @@ export default function WineForm({
 
   const [priceError, setPriceError] = useState('');
   const [imgError, setImgError] = useState('');
+
+  // placeholder 랜덤 값
+  const [randomPlaceholders] = useState(() => ({
+    name: WINE_NAME_PLACEHOLDERS[
+      Math.floor(Math.random() * WINE_NAME_PLACEHOLDERS.length)
+    ],
+    region:
+      REGION_PLACEHOLDERS[
+        Math.floor(Math.random() * REGION_PLACEHOLDERS.length)
+      ],
+    price:
+      PRICE_PLACEHOLDERS[Math.floor(Math.random() * PRICE_PLACEHOLDERS.length)],
+  }));
 
   // 이미지 미리보기를 위한 src 설정
   const imageSrc =
@@ -132,7 +171,7 @@ export default function WineForm({
       <InputPair
         inputClassName={INPUT_CLASSNAME}
         label='와인 이름'
-        placeholder={isEdit ? wineData.name : '페이덜트 고잉 포 브로크'}
+        placeholder={isEdit ? wineData.name : randomPlaceholders.name}
         type='text'
         value={formData.name}
         onChange={handleChange('name')}
@@ -144,7 +183,9 @@ export default function WineForm({
             priceError && 'border-red-500 focus:border-2 focus:border-red-500',
           )}
           label='가격'
-          placeholder={isEdit ? String(wineData.price) : '64,900'}
+          placeholder={
+            isEdit ? String(wineData.price) : randomPlaceholders.price
+          }
           type='text'
           value={
             formData.price === 0 ? '' : formData.price.toLocaleString('ko-KR')
@@ -159,9 +200,7 @@ export default function WineForm({
       <InputPair
         inputClassName={INPUT_CLASSNAME}
         label='원산지'
-        placeholder={
-          isEdit ? wineData.region : 'Sonoma County, California, USA'
-        }
+        placeholder={isEdit ? wineData.region : randomPlaceholders.region}
         type='text'
         value={formData.region}
         onChange={handleChange('region')}

--- a/src/components/WineInfo.tsx
+++ b/src/components/WineInfo.tsx
@@ -93,14 +93,14 @@ export default function WineInfo({
       <div className='flex h-full w-full gap-4'>
         <div
           className={cn(
-            'relative aspect-[3/4] w-full max-w-xs',
+            'relative aspect-[10/26] h-[22rem] w-[10rem] md:h-[22rem] md:w-[10rem] xl:h-[26rem] xl:w-[10rem]',
             wineImageClassName,
           )}
         >
           <Image
             fill
             alt='wine Image'
-            className='object-cover'
+            className='object-cover px-6 xl:px-5'
             src={wineImage}
           />
         </div>


### PR DESCRIPTION
### 📌 관련 이슈

- #209

### 📋 작업 내용

- 목록 페이지에 와인 크기를 전체적으로 동일하게 보일 수 있도록 수정했습니다.
- 와인 등록 Form에서 placeholder가 랜덤으로 보일 수 있도록 수정했습니다.

## 06.22 수정사항
### LoadMoreBtn을 통해 받아오는 데이터의 최신화 불가능 이슈

**문제 상황**
와인을 수정한 뒤 router.refresh()를 호출하고 있지만, "더 보기"로 불러온 와인 목록이 갱신되지 않고 수정 전 데이터가 그대로 표시되는 현사이 발생했습니다.

**원인**
LoadMoreButton 컴포넌트에서 추가로 불러온 데이터(items)는 클라이언트 상태(useState)로만 관리되고 있었습니다.
`router.refresh()`는 서버 컴포넌트는 새로고침하지만 클라이언트 state는 초기화되지 않아 기존 데이터를 그대로 보여주게 된 것입니다.

**해결 방법**
useEffect에서 initialCursor가 바뀌면 items와 cursor 상태를 초기화하도록 수정하여
`router.refresh()` 후 부모 컴포넌트가 initialCursor를 새로 전달하면서 LoadMoreButton 내부 state도 초기화되어 최신 데이터를 반영할 수 있도록 변경하였습니다.

### 📷 결과 및 스크린샷

### PC

https://github.com/user-attachments/assets/11234377-4b4a-4593-8f97-a1bfffc4c874

### 테블릿

https://github.com/user-attachments/assets/894bf656-8f57-4f96-8439-48b3aea02f5e

### 모바일

... 용량이 너무 크다고 합니다 ㅠㅠ 사진으로 대체하겠습니다
![image](https://github.com/user-attachments/assets/64d980ef-00fe-4490-aa80-efac711a0551)


###  와인폼

https://github.com/user-attachments/assets/479131ef-aa86-4d21-a97b-7eb45f34e001


### 🔎 참고 (선택)

- 다소 하드 코딩된 부분이 있긴 하지만, 현재 등록된 와인들 기준으로는 최대한 크기가 일정하게 보이도록 조정했습니다 ㅠㅠ