### PR TITLE
revalidateTag로 캐싱 무효화가 되지 않는 오류 해결

### DIFF
--- a/src/app/api/wines/revalidate-recommended-wines/route.ts
+++ b/src/app/api/wines/revalidate-recommended-wines/route.ts
@@ -1,4 +1,4 @@
-import { revalidateTag } from 'next/cache';
+import { revalidatePath } from 'next/cache';
 
 /**
  * @description
@@ -6,7 +6,7 @@ import { revalidateTag } from 'next/cache';
  */
 export async function POST() {
   try {
-    revalidateTag('recommended-wines');
+    revalidatePath('/wines');
     return new Response('Revalidated', { status: 200 });
   } catch (error) {
     console.error('캐시 무효화 실패:', error);


### PR DESCRIPTION
### 📌 관련 이슈

- #228

### 📋 작업 내용

**문제 상황**
와인 데이터가 변동되면 캐싱 무효화가 일어나야 하는데,` revalidateTag()`가 실행되어도 캐싱 무효화가 되지 않는 오류가 있었습니다.

**원인**
여러 방법을 시도해봤지만 원인을 찾지 못했고, 
최근 Next 이슈에서 저와 비슷한 상황이 언급되는 것을 보았습니다.
[revalidateTag 관련 이슈](https://github.com/vercel/next.js/issues/80627)

**해결 방법**
`revalidatePath("/wines")`로 캐싱 무효화를 진행했습니다.
하지만... 현재 `revalidatePath()`도 전체 페이지들의 캐싱이 무효화되는 오류가 있다고는 하네요...ㅠ
그래도 저희 프로젝트에서는 서버에서 캐싱을 적용한게 추천 와인 뿐이라 괜찮을 것 같다고 생각합니다..ㅎㅎ


### 📷 결과 및 스크린샷

|캐싱 무효화|캐싱도 가능합니다|
|----------|----------------|
|![revalidatePath로 캐싱 무효화 해결](https://github.com/user-attachments/assets/e6f6be7e-fc75-4467-8471-54c5099ea65e)|![캐싱은 계속 적용됨](https://github.com/user-attachments/assets/2e77efd6-adc5-496f-890f-034fb1c97510)|

### 🔎 참고 (선택)
